### PR TITLE
feat: カレンダーイベントに時刻情報を追加

### DIFF
--- a/docs/phase1.5-datasources.md
+++ b/docs/phase1.5-datasources.md
@@ -46,6 +46,7 @@ flowchart TB
 - `config/client_secret.json` にクライアントIDを配置（gitignore対象）
 - 初回実行時にブラウザ認証 → `config/token.json` が生成される
 - Events.list APIで7日間のイベントを取得
+- イベントの時刻情報を含む（時刻付き: `"09:00-10:00 会議"`, 終日: `"終日: 出張"`）
 
 ### Open-Meteo API
 - APIキー不要・無料・無制限
@@ -69,7 +70,7 @@ class Location(BaseModel):
 class CalendarSlot(BaseModel):
     date: date
     available: bool
-    events: list[str] = []
+    events: list[str] = []  # 時刻付き: "09:00-10:00 会議", 終日: "終日: 出張"
 
 class DailyWeather(BaseModel):
     date: date

--- a/run_coach/calendar.py
+++ b/run_coach/calendar.py
@@ -58,10 +58,25 @@ def _fetch_events(service) -> dict[date, list[str]]:
 
     events_by_date: dict[date, list[str]] = {}
     for event in events_result.get("items", []):
-        start = event["start"].get("dateTime", event["start"].get("date", ""))
-        event_date = date.fromisoformat(start[:10])
         summary = event.get("summary", "(無題)")
-        events_by_date.setdefault(event_date, []).append(summary)
+        start_dt = event["start"].get("dateTime")
+        if start_dt:
+            event_date = date.fromisoformat(start_dt[:10])
+            start_time = datetime.fromisoformat(start_dt).strftime("%H:%M")
+            end_dt = event["end"].get("dateTime", "")
+            end_time = (
+                datetime.fromisoformat(end_dt).strftime("%H:%M") if end_dt else ""
+            )
+            label = (
+                f"{start_time}-{end_time} {summary}"
+                if end_time
+                else f"{start_time} {summary}"
+            )
+        else:
+            start_date_str = event["start"].get("date", "")
+            event_date = date.fromisoformat(start_date_str)
+            label = f"終日: {summary}"
+        events_by_date.setdefault(event_date, []).append(label)
 
     return events_by_date
 

--- a/run_coach/planner.py
+++ b/run_coach/planner.py
@@ -123,7 +123,7 @@ def _build_prompt(state: AgentState) -> str:
             if slot.available:
                 parts.append(f"- {slot.date}: 空き")
             else:
-                parts.append(f"- {slot.date}: 予定あり ({', '.join(slot.events)})")
+                parts.append(f"- {slot.date}: {' / '.join(slot.events)}")
 
     if constraints.weather:
         parts.append("\n## 天気予報（今後7日間）")

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -10,15 +10,28 @@ def test_calendar_slot_available():
     assert slot.events == []
 
 
-def test_calendar_slot_busy():
-    """予定ありスロットが正しく生成できること"""
+def test_calendar_slot_busy_with_time():
+    """時刻付き予定ありスロットが正しく生成できること"""
     slot = CalendarSlot(
         date=date(2026, 3, 10),
         available=False,
-        events=["会議", "ランチ"],
+        events=["09:00-10:00 会議", "12:00-13:00 ランチ"],
     )
     assert slot.available is False
     assert len(slot.events) == 2
+    assert slot.events[0] == "09:00-10:00 会議"
+    assert slot.events[1] == "12:00-13:00 ランチ"
+
+
+def test_calendar_slot_all_day_event():
+    """終日イベントが正しく生成できること"""
+    slot = CalendarSlot(
+        date=date(2026, 3, 11),
+        available=False,
+        events=["終日: 出張"],
+    )
+    assert slot.available is False
+    assert slot.events[0] == "終日: 出張"
 
 
 def test_build_slots_logic():
@@ -26,8 +39,8 @@ def test_build_slots_logic():
     from datetime import timedelta
 
     events_by_date = {
-        date(2026, 3, 10): ["会議"],
-        date(2026, 3, 12): ["出張", "会食"],
+        date(2026, 3, 10): ["09:00-10:00 会議"],
+        date(2026, 3, 12): ["終日: 出張", "19:00-20:00 会食"],
     }
 
     today = date(2026, 3, 9)
@@ -40,6 +53,9 @@ def test_build_slots_logic():
     assert len(slots) == 7
     assert slots[0].available is True  # 3/9: no events
     assert slots[1].available is False  # 3/10: 会議
+    assert slots[1].events == ["09:00-10:00 会議"]
     assert slots[2].available is True  # 3/11: no events
     assert slots[3].available is False  # 3/12: 出張, 会食
     assert len(slots[3].events) == 2
+    assert slots[3].events[0] == "終日: 出張"
+    assert slots[3].events[1] == "19:00-20:00 会食"


### PR DESCRIPTION
## Summary
- カレンダーイベントに時刻情報を含めることで、LLMが空き時間帯を判断できるようにする
- 時刻付きイベント: `"09:00-10:00 会議"` / 終日イベント: `"終日: 出張"`
- プランナーの表示形式を `予定あり (会議, ランチ)` → `09:00-10:00 会議 / 12:00-13:00 ランチ` に変更

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `run_coach/calendar.py` | `_fetch_events()`で時刻付き文字列を生成 |
| `run_coach/planner.py` | カレンダーセクションの表示形式変更 |
| `tests/test_calendar.py` | 時刻付き・終日イベントのテストケース追加 |
| `docs/phase1.5-datasources.md` | eventsに時刻を含む旨を追記 |

## Test plan
- [x] `uv run pytest tests/ -v` — 全18テスト合格
- [ ] `uv run python -m run_coach` でカレンダーに時刻付き表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)