### PR TITLE
fix: Mypy/Pylanceの型エラー・lint指摘を修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ dev = [
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
     "ruff>=0.15.5",
+    "types-pyyaml>=6.0.12.20250915",
 ]

--- a/run_coach/calendar.py
+++ b/run_coach/calendar.py
@@ -4,10 +4,10 @@ import logging
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
-from google.auth.transport.requests import Request
-from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
-from googleapiclient.discovery import Resource, build
+from google.auth.transport.requests import Request  # type: ignore[import-untyped]
+from google.oauth2.credentials import Credentials  # type: ignore[import-untyped]
+from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import-untyped]
+from googleapiclient.discovery import Resource, build  # type: ignore[import-untyped]
 
 from run_coach.state import AgentState, CalendarSlot
 

--- a/run_coach/garmin.py
+++ b/run_coach/garmin.py
@@ -97,7 +97,9 @@ def fetch_workouts(state: AgentState) -> AgentState:
     """Fetch recent workouts from Garmin Connect and populate state.signals."""
     client = _login()
 
-    activities = client.get_activities(start=0, limit=ACTIVITY_FETCH_LIMIT)
+    # get_activities() の戻り値は dict | list なので型を絞り込む
+    raw_activities = client.get_activities(start=0, limit=ACTIVITY_FETCH_LIMIT)
+    activities: list[dict] = raw_activities if isinstance(raw_activities, list) else []
 
     cutoff = date.today() - timedelta(days=LOOKBACK_DAYS)
     workouts: list[WorkoutSummary] = []
@@ -124,7 +126,11 @@ def fetch_workouts(state: AgentState) -> AgentState:
 def _fetch_race_detail(client: Garmin, event_id: int) -> RaceEvent | None:
     """Fetch race event detail from Garmin Calendar API."""
     try:
-        event_detail = client.garth.connectapi(f"/calendar-service/event/{event_id}")
+        # connectapi() の戻り値は dict | list | None なので型を絞り込む
+        raw = client.garth.connectapi(f"/calendar-service/event/{event_id}")
+        if not isinstance(raw, dict):
+            return None
+        event_detail: dict = raw
         event_name = event_detail.get("eventName", event_detail.get("title", "Unknown"))
         event_date_str = event_detail.get("date", "")
         if not event_date_str:
@@ -168,7 +174,7 @@ def fetch_races(state: AgentState) -> AgentState:
 
         try:
             # Garmin Calendar APIの月インデックス: 0始まり
-            monthly_calendar = client.garth.connectapi(
+            raw_calendar = client.garth.connectapi(
                 f"/calendar-service/year/{target_year}/month/{target_month - 1}",
             )
         except Exception as e:
@@ -177,6 +183,10 @@ def fetch_races(state: AgentState) -> AgentState:
             )
             continue
 
+        # connectapi() の戻り値は dict | list | None なので型を絞り込む
+        if not isinstance(raw_calendar, dict):
+            continue
+        monthly_calendar: dict = raw_calendar
         for item in monthly_calendar.get("calendarItems", []):
             if item.get("itemType") != "event" or not item.get("isRace"):
                 continue

--- a/run_coach/planner.py
+++ b/run_coach/planner.py
@@ -59,7 +59,7 @@ def call_llm(prompt: str, system: str = "") -> str:
         if system:
             messages.append({"role": "system", "content": system})
         messages.append({"role": "user", "content": prompt})
-        response = client.chat.completions.create(
+        response = client.chat.completions.create(  # type: ignore[call-overload]
             model=os.environ.get("LLM_MODEL", DEFAULT_LLM_MODEL),
             messages=messages,
             temperature=0.7,

--- a/uv.lock
+++ b/uv.lock
@@ -990,6 +990,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -1008,6 +1009,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.15.5" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
 [[package]]
@@ -1029,6 +1031,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- calendar.py: googleインポートに `# type: ignore[import-untyped]` を追加
- garmin.py: `get_activities()` / `connectapi()` の戻り値を `isinstance` で型絞り込み
- planner.py: OpenAI `create()` に `# type: ignore[call-overload]` を追加
- `types-PyYAML` をdev依存に追加（Mypyのimport-untyped解消）

## Test plan
- [x] `uv run pytest tests/` 全18テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)