### PR TITLE
docs: Phase 3・5 のスコープを整理

### DIFF
--- a/docs/phase3-langgraph.md
+++ b/docs/phase3-langgraph.md
@@ -1,10 +1,11 @@
 # Phase 3: LangGraph でフロー制御移行
 
-自前実装をLangGraphのステートグラフに移行し、セルフチェックの条件分岐をグラフで管理。
+自前実装のフロー制御をLangGraphのステートグラフに置き換える。機能追加はしない。
 
 ## ゴール
 
-自前のフロー制御をLangGraphに置き換え、セルフチェックや対話ループを実装する。
+Phase 1〜2で作った自前のフロー制御（関数の順次呼び出し + if文分岐）をLangGraphのStateGraphに載せ替える。
+**既存の動作を変えずに、フロー制御の仕組みだけを入れ替える。**
 
 ## フロー
 
@@ -14,24 +15,18 @@ flowchart TB
     START --> FG[fetch_garmin<br>Node]
     FG --> FC[fetch_calendar<br>Node]
     FC --> FW[fetch_weather<br>Node]
-    FW --> RET[retrieve<br>RAG検索 Node]
-    RET --> GR[apply_guardrails<br>Node]
+    FW --> GR[apply_guardrails<br>Node]
     GR --> GEN[generate_plan<br>LLM Node]
     GEN --> CHK[self_check<br>Node]
 
     CHK -->|OK| OUT[output_plan<br>Node]
     CHK -->|NG: ルール違反| GEN
 
-    OUT --> UF{ユーザー確認}
-    UF -->|承認| SAVE[save_decision<br>Node]
-    UF -->|修正要望| GEN
-
-    SAVE --> END((END))
+    OUT --> END((END))
 
     style START fill:#2ed573,color:#fff
     style END fill:#2ed573,color:#fff
     style CHK fill:#e74c3c,color:#fff
-    style UF fill:#4a9eff,color:#fff
 ```
 
 ## やること
@@ -40,9 +35,6 @@ flowchart TB
 - [ ] 各関数をLangGraphのNodeとして登録
 - [ ] Edge（直線フロー）の定義
 - [ ] Conditional Edge（セルフチェック結果による分岐）の定義
-- [ ] ヒューマンリフレクション（ユーザー確認ループ）の実装
-- [ ] RAG部分にLangChainのRetrieverを導入
-- [ ] ツールをLangChainのTool形式に移行
 
 ## 自前実装 → LangGraph の対応
 
@@ -60,24 +52,22 @@ from langgraph.graph import StateGraph, END
 
 graph = StateGraph(AgentState)
 
-# ノード登録
+# ノード登録（Phase 1〜2の既存関数をそのまま使う）
 graph.add_node("fetch_garmin", fetch_garmin)
 graph.add_node("fetch_calendar", fetch_calendar)
 graph.add_node("fetch_weather", fetch_weather)
-graph.add_node("retrieve", retrieve_context)
 graph.add_node("apply_guardrails", apply_guardrails)
 graph.add_node("generate_plan", generate_plan)
 graph.add_node("self_check", self_check)
 graph.add_node("output_plan", output_plan)
-graph.add_node("save_decision", save_decision)
 
 # エッジ
 graph.set_entry_point("fetch_garmin")
 graph.add_edge("fetch_garmin", "fetch_calendar")
 graph.add_edge("fetch_calendar", "fetch_weather")
-graph.add_edge("fetch_weather", "retrieve")
-graph.add_edge("retrieve", "apply_guardrails")
+graph.add_edge("fetch_weather", "apply_guardrails")
 graph.add_edge("apply_guardrails", "generate_plan")
+graph.add_edge("generate_plan", "self_check")
 
 # 条件分岐: セルフチェック
 graph.add_conditional_edges("self_check", check_result, {
@@ -85,13 +75,7 @@ graph.add_conditional_edges("self_check", check_result, {
     "ng": "generate_plan",
 })
 
-# 条件分岐: ユーザー確認
-graph.add_conditional_edges("output_plan", user_feedback, {
-    "approved": "save_decision",
-    "revise": "generate_plan",
-})
-
-graph.add_edge("save_decision", END)
+graph.add_edge("output_plan", END)
 
 app = graph.compile()
 ```

--- a/docs/phase5-cloud-run.md
+++ b/docs/phase5-cloud-run.md
@@ -4,7 +4,7 @@ Cloud Runにデプロイし、自動実行環境を構築。
 
 ## ゴール
 
-Macを閉じていても自動でプラン生成・通知・振り返り収集が動く状態にする。
+Macを閉じていても自動でプラン生成・LINE通知が動く状態にする。
 
 ## フロー
 
@@ -17,8 +17,7 @@ flowchart TB
     subgraph CR[Cloud Run: run-coach]
         FG[fetch_garmin] --> FC[fetch_calendar<br>Google Calendar API]
         FC --> FW[fetch_weather]
-        FW --> RET[RAG検索]
-        RET --> GR[ガードレール]
+        FW --> GR[ガードレール]
         GR --> GEN[LLM: プラン生成]
         GEN --> CHK[セルフチェック]
         CHK -->|OK| PUSH[LINE Push通知]
@@ -31,101 +30,38 @@ flowchart TB
     style CR fill:#f5f5f5,color:#333
 ```
 
-### ラン後の自動振り返り
-
-```mermaid
-flowchart TB
-    CS2[Cloud Scheduler<br>毎時チェック] -->|HTTP| CR2
-
-    subgraph CR2[Cloud Run: run-coach]
-        CHK2[Garmin新着チェック] -->|新着あり| SUM[ワークアウト要約]
-        SUM --> PUSH2[LINE Push<br>どうだった？]
-    end
-
-    PUSH2 --> U2[ユーザーのLINE]
-    U2 -->|返信| WH[LINE Webhook]
-
-    subgraph CR3[Cloud Run: Webhook処理]
-        WH --> LLM2[LLM: 振り返り整形]
-        LLM2 --> SAVE[SQLite + ChromaDB<br>に保存]
-        SAVE --> REPLY[LINE返信<br>記録しました]
-    end
-
-    REPLY --> U2
-
-    style CS2 fill:#4a9eff,color:#fff
-    style U2 fill:#2ed573,color:#fff
-```
-
-### LLMOps評価
-
-```mermaid
-flowchart LR
-    D[Decision<br>プラン生成] --> O[Outcome<br>実施結果]
-    O --> E[評価パイプライン<br>プラン vs 実績]
-    E --> PV[プロンプト改善<br>バージョン管理]
-    PV --> D
-
-    style E fill:#e74c3c,color:#fff
-```
-
 ## やること
 
 ### Cloud Run デプロイ
 
 - [ ] Dockerfile作成
 - [ ] Cloud Runサービスのデプロイ
-- [ ] Cloud Schedulerの設定（週次プラン / Garmin新着チェック）
+- [ ] Cloud Schedulerの設定（週次プラン生成トリガー）
 - [ ] Google Calendar APIのサービスアカウント設定
 - [ ] Secret Managerで認証情報を管理（Garmin / LLM API / LINE）
 
-### LINE連携（段階的に）
+### HTTPエンドポイント
 
-- [ ] LINE公式アカウント作成 + Messaging API設定
-- [ ] Step 1: Push通知のみ（週次プラン / 今日のメニュー）
-- [ ] Step 2: Webhook受信（ユーザーの返信を処理）
-- [ ] Step 3: 振り返り記録（LINE → SQLite + ChromaDB）
-- [ ] Step 4: 対話型プラン調整（「来週は水曜しか走れない」等）
-
-### Garmin書き戻し（できたら嬉しいレベル）
-
-- [ ] `garth.put()` でdescriptionフィールドに振り返りを書き戻し
-- [ ] 実装時にAPIの挙動を要検証
-
-### LLMOps評価基盤
-
-- [ ] プロンプトバージョン管理（llm_callsテーブルのprompt_version）
-- [ ] Decision vs Outcomeの比較（プランと実績のギャップ分析）
-- [ ] 評価パイプライン（週次で自動評価）
-- [ ] 改善ループ（評価結果をプロンプト改善にフィードバック）
+- [ ] `/generate` — Cloud Schedulerから呼ばれ、プラン生成 → LINE Push通知
+- [ ] ヘルスチェック用エンドポイント
 
 ## テスト方針
 
-- [ ] 既存テスト全通し: Phase 1-4のテストがCloud Run環境でも通ること（LangGraph含む）
-- [ ] Webhook処理: LINEからのリクエストを正しくパースできるか
-- [ ] Push通知: LLM出力→LINE送信の変換が正しいか
+- [ ] 既存テスト全通し: Phase 1〜4のテストがCloud Run環境でも通ること
 - [ ] 認証: Secret Managerからの認証情報取得が動くか
+- [ ] HTTPエンドポイント: `/generate` が正しくプラン生成→LINE通知を実行するか
 - [ ] E2Eテスト: Cloud Scheduler → Cloud Run → LINE の一連の流れ
 
 ```python
 # テスト例
-def test_line_webhook_parse():
-    """LINEからのWebhookリクエストをパースできるか"""
-    raw = {"events": [{"type": "message", "message": {"text": "脚が重かった"}, ...}]}
-    parsed = parse_line_webhook(raw)
-    assert parsed["text"] == "脚が重かった"
+def test_generate_endpoint(client):
+    """/generate エンドポイントが正常に動作するか"""
+    response = client.post("/generate")
+    assert response.status_code == 200
 
-def test_plan_to_line_message():
-    """週次プランJSONをLINE送信用メッセージに変換"""
-    plan = Plan(week_start="2026-03-09", days=[...], ...)
-    message = format_plan_for_line(plan)
-    assert "2026-03-09" in message
-    assert "イージーラン" in message
-
-def test_garmin_new_activity_detection():
-    """前回チェック以降の新着ワークアウトを検出"""
-    last_check = "2026-03-05T00:00:00"
-    activities = [{"startTimeLocal": "2026-03-06 08:00", ...}]
-    new = detect_new_activities(activities, last_check)
-    assert len(new) == 1
+def test_secret_manager_integration():
+    """Secret Managerから認証情報を取得できるか"""
+    # モック環境での検証
+    secret = get_secret("GARMIN_EMAIL")
+    assert secret is not None
 ```


### PR DESCRIPTION
## Summary
- Phase 3: RAG・ユーザー確認ループ・LangChain Tool移行を削除し、フロー制御の載せ替えに集中
- Phase 5: 振り返り機能・LLMOps・Garmin書き戻しを削除し、デプロイ+LINE Push通知に集中

## Test plan
- [x] ドキュメント変更のみ、コード変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)