### PR TITLE
feat: LLMモデル・レビュー回数の設定を外部化

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,6 +42,9 @@ run-coach/
 │   └── formatter.py       # JSON → Markdown 変換
 ├── tests/                 # テスト
 ├── docs/                  # Phase毎の詳細設計
+├── config/                # 設定ファイル
+│   ├── settings.yaml      # アプリケーション設定（LLMモデル等）
+│   └── settings.example.yaml
 ├── DESIGN.md              # 全体設計書
 ├── pyproject.toml         # uv プロジェクト設定
 ├── .env.example           # 必要な環境変数の一覧

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ PLAN_*.md
 
 # User config (contains personal data)
 config/profile.yaml
+config/settings.yaml
 
 # Garmin tokens
 .garminconnect/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -512,6 +512,16 @@ export GARMIN_PASSWORD="..."
 export OPENAI_API_KEY="..."
 ```
 
+### アプリケーション設定: config/settings.yaml
+
+LLMモデル等のアプリケーション設定は `config/settings.yaml` で管理する。
+設定ファイルがない場合はデフォルト値（gpt-4o-mini）が使われる。
+
+```yaml
+llm_model: "gpt-4o-mini"  # OpenAI model name (e.g. gpt-4o, gpt-4o-mini, o3-mini)
+plan_review_max_retries: 2  # セルフチェックNGの場合の再生成回数上限
+```
+
 ```bash
 # 実行
 uv run python -m run_coach

--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -1,0 +1,2 @@
+llm_model: "gpt-4o-mini"  # OpenAI model name (e.g. gpt-4o, gpt-4o-mini, o3-mini)
+plan_review_max_retries: 2  # セルフチェックNGの場合の再生成回数上限

--- a/run_coach/__main__.py
+++ b/run_coach/__main__.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
-from run_coach.config import load_profile
+from run_coach.config import load_profile, load_settings
 from run_coach.graph import compile_graph
+from run_coach.planner import set_plan_review_max_retries
+from run_coach.prompt import set_llm_model
 from run_coach.state import AgentState
 
 
 def main() -> None:
+    settings = load_settings()
+    set_llm_model(settings["llm_model"])
+    set_plan_review_max_retries(int(settings["plan_review_max_retries"]))
+
     profile = load_profile()
     state = AgentState(user_profile=profile)
     app = compile_graph()

--- a/run_coach/config.py
+++ b/run_coach/config.py
@@ -7,6 +7,12 @@ import yaml
 from run_coach.state import UserProfile
 
 DEFAULT_CONFIG_PATH = Path("config/profile.yaml")
+DEFAULT_SETTINGS_PATH = Path("config/settings.yaml")
+
+DEFAULT_SETTINGS: dict[str, str | int] = {
+    "llm_model": "gpt-4o-mini",
+    "plan_review_max_retries": 2,
+}
 
 
 def load_profile(path: Path = DEFAULT_CONFIG_PATH) -> UserProfile:
@@ -17,3 +23,16 @@ def load_profile(path: Path = DEFAULT_CONFIG_PATH) -> UserProfile:
         )
     data = yaml.safe_load(path.read_text())
     return UserProfile(**data)
+
+
+def load_settings(path: Path = DEFAULT_SETTINGS_PATH) -> dict[str, str | int]:
+    """Load application settings from a YAML file.
+
+    Returns default values if the file does not exist.
+    """
+    settings = dict(DEFAULT_SETTINGS)
+    if path.exists():
+        data = yaml.safe_load(path.read_text())
+        if data:
+            settings.update(data)
+    return settings

--- a/run_coach/planner.py
+++ b/run_coach/planner.py
@@ -7,6 +7,13 @@ from run_coach.state import AgentState, Plan
 
 PLAN_REVIEW_MAX_RETRIES = 2
 
+
+def set_plan_review_max_retries(value: int) -> None:
+    """プランレビューの最大リトライ回数を設定する。"""
+    global PLAN_REVIEW_MAX_RETRIES  # noqa: PLW0603
+    PLAN_REVIEW_MAX_RETRIES = value
+
+
 PLANNER_SYSTEM_PROMPT = (
     "あなたは経験豊富なランニングコーチです。\n"
     "選手のプロフィール、最近のワークアウト履歴、レース予測タイム、\n"

--- a/run_coach/prompt.py
+++ b/run_coach/prompt.py
@@ -15,6 +15,23 @@ from run_coach.state import (
 # デフォルトのLLMモデル（環境変数 LLM_MODEL で上書き可能）
 DEFAULT_LLM_MODEL = "gpt-4o-mini"
 
+# モジュールレベル変数: set_llm_model() で設定される
+_llm_model: str | None = None
+
+
+def set_llm_model(model: str) -> None:
+    """Set the LLM model to use for all subsequent call_llm() calls."""
+    global _llm_model  # noqa: PLW0603
+    _llm_model = model
+
+
+def get_llm_model() -> str:
+    """Resolve the LLM model: module variable → env var → default."""
+    if _llm_model:
+        return _llm_model
+    return os.environ.get("LLM_MODEL", DEFAULT_LLM_MODEL)
+
+
 COACHING_RULES = """\
 1. 高強度セッション（tempo, intervals）は週2回まで
 2. ロング走の翌日は必ずイージーランまたは休養
@@ -38,7 +55,7 @@ def call_llm(prompt: str, system: str = "") -> str:
             messages.append({"role": "system", "content": system})
         messages.append({"role": "user", "content": prompt})
         response = client.chat.completions.create(  # type: ignore[call-overload]
-            model=os.environ.get("LLM_MODEL", DEFAULT_LLM_MODEL),
+            model=get_llm_model(),
             messages=messages,
             temperature=0.7,
             response_format={"type": "json_object"},


### PR DESCRIPTION
## Summary
- `config/settings.yaml` を新設し、LLMモデル名(`llm_model`)とプランレビュー最大リトライ回数(`plan_review_max_retries`)を外部設定化
- 設定ファイルがない場合はデフォルト値（gpt-4o-mini, retries=2）でフォールバック
- `config/settings.yaml` は `.gitignore` 対象、`config/settings.example.yaml` をテンプレートとして提供

## Test plan
- [x] `uv run pytest tests/ -v` で既存テスト全30件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)