### PR TITLE
feat: デバッグ出力機能を追加

### DIFF
--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -1,2 +1,3 @@
 llm_model: "gpt-4o-mini"  # OpenAI model name (e.g. gpt-4o, gpt-4o-mini, o3-mini)
 plan_review_max_retries: 2  # セルフチェックNGの場合の再生成回数上限
+debug: false  # trueでLLM生成プラン・レビュー結果を出力

--- a/run_coach/__main__.py
+++ b/run_coach/__main__.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 from run_coach.config import load_profile, load_settings
 from run_coach.graph import compile_graph
 from run_coach.planner import set_plan_review_max_retries
-from run_coach.prompt import set_llm_model
+from run_coach.prompt import set_debug, set_llm_model
 from run_coach.state import AgentState
 
 
 def main() -> None:
     settings = load_settings()
-    set_llm_model(settings["llm_model"])
+    set_llm_model(str(settings["llm_model"]))
     set_plan_review_max_retries(int(settings["plan_review_max_retries"]))
+    set_debug(bool(settings.get("debug", False)))
 
     profile = load_profile()
     state = AgentState(user_profile=profile)

--- a/run_coach/config.py
+++ b/run_coach/config.py
@@ -9,9 +9,10 @@ from run_coach.state import UserProfile
 DEFAULT_CONFIG_PATH = Path("config/profile.yaml")
 DEFAULT_SETTINGS_PATH = Path("config/settings.yaml")
 
-DEFAULT_SETTINGS: dict[str, str | int] = {
+DEFAULT_SETTINGS: dict[str, str | int | bool] = {
     "llm_model": "gpt-4o-mini",
     "plan_review_max_retries": 2,
+    "debug": False,
 }
 
 
@@ -25,7 +26,7 @@ def load_profile(path: Path = DEFAULT_CONFIG_PATH) -> UserProfile:
     return UserProfile(**data)
 
 
-def load_settings(path: Path = DEFAULT_SETTINGS_PATH) -> dict[str, str | int]:
+def load_settings(path: Path = DEFAULT_SETTINGS_PATH) -> dict[str, str | int | bool]:
     """Load application settings from a YAML file.
 
     Returns default values if the file does not exist.

--- a/run_coach/plan_review.py
+++ b/run_coach/plan_review.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from run_coach.prompt import COACHING_RULES, build_prompt, call_llm
+from run_coach.prompt import COACHING_RULES, build_prompt, call_llm, is_debug
 from run_coach.state import AgentState
 
 PLAN_REVIEW_SYSTEM_PROMPT = (
@@ -60,4 +60,10 @@ def review_plan(state: AgentState) -> AgentState:
 
     state.review_result = data.get("result", "ng")
     state.review_violations = data.get("violations", [])
+    if is_debug():
+        print(f"\n[DEBUG] レビュー結果: {state.review_result}")
+        if state.review_violations:
+            print("[DEBUG] 指摘事項:")
+            for violation in state.review_violations:
+                print(f"  - {violation}")
     return state

--- a/run_coach/planner.py
+++ b/run_coach/planner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from run_coach.prompt import COACHING_RULES, build_prompt, call_llm
+from run_coach.prompt import COACHING_RULES, build_prompt, call_llm, is_debug
 from run_coach.state import AgentState, Plan
 
 PLAN_REVIEW_MAX_RETRIES = 2
@@ -79,6 +79,9 @@ def generate_plan(state: AgentState) -> AgentState:
 
     data = json.loads(raw)
     state.plan = Plan(**data)
+    if is_debug():
+        print("\n[DEBUG] 生成されたプラン:")
+        print(state.plan.model_dump_json(indent=2))
     state.review_violations = []
     state.review_result = None
     return state

--- a/run_coach/prompt.py
+++ b/run_coach/prompt.py
@@ -32,6 +32,21 @@ def get_llm_model() -> str:
     return os.environ.get("LLM_MODEL", DEFAULT_LLM_MODEL)
 
 
+# デバッグモード: set_debug() で設定される
+_debug: bool = False
+
+
+def set_debug(enabled: bool) -> None:
+    """デバッグ出力を有効/無効にする。"""
+    global _debug  # noqa: PLW0603
+    _debug = enabled
+
+
+def is_debug() -> bool:
+    """デバッグモードが有効かどうかを返す。"""
+    return _debug
+
+
 COACHING_RULES = """\
 1. 高強度セッション（tempo, intervals）は週2回まで
 2. ロング走の翌日は必ずイージーランまたは休養


### PR DESCRIPTION
## Summary
- `config/settings.yaml` に `debug` 設定を追加（デフォルト `false`）
- `true` にすると `generate_plan` 後のプランJSONと `review_plan` 後のレビュー結果・指摘事項を `[DEBUG]` タグ付きで標準出力に表示
- `prompt.py` に `set_debug()` / `is_debug()` を追加し、既存の `set_llm_model` と同じモジュール変数パターンで管理

## Test plan
- [x] `uv run pytest tests/ -v` で既存テスト全30件パス
- [x] `debug: true` で実行し、プランJSON・レビュー結果が出力されることを確認
- [x] `debug: false` で実行し、デバッグ出力が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)