### PR TITLE
refactor: 設定初期化を apply_settings() に集約

### DIFF
--- a/run_coach/__main__.py
+++ b/run_coach/__main__.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-from run_coach.config import load_profile, load_settings
+from run_coach.config import apply_settings, load_profile, load_settings
 from run_coach.graph import compile_graph
-from run_coach.planner import set_plan_review_max_retries
-from run_coach.prompt import set_debug, set_llm_model
 from run_coach.state import AgentState
 
 
 def main() -> None:
     settings = load_settings()
-    set_llm_model(str(settings["llm_model"]))
-    set_plan_review_max_retries(int(settings["plan_review_max_retries"]))
-    set_debug(bool(settings.get("debug", False)))
+    apply_settings(settings)
 
     profile = load_profile()
     state = AgentState(user_profile=profile)

--- a/run_coach/config.py
+++ b/run_coach/config.py
@@ -37,3 +37,13 @@ def load_settings(path: Path = DEFAULT_SETTINGS_PATH) -> dict[str, str | int | b
         if data:
             settings.update(data)
     return settings
+
+
+def apply_settings(settings: dict[str, str | int | bool]) -> None:
+    """設定値を各モジュールに反映する。"""
+    from run_coach.planner import set_plan_review_max_retries
+    from run_coach.prompt import set_debug, set_llm_model
+
+    set_llm_model(str(settings["llm_model"]))
+    set_plan_review_max_retries(int(settings["plan_review_max_retries"]))
+    set_debug(bool(settings.get("debug", False)))


### PR DESCRIPTION
## Summary
- `config.py` に `apply_settings()` を追加し、`__main__.py` の個別setter呼び出し3つを1行に集約
- 設定項目追加時の修正箇所を `config.py` に一元化

## Test plan
- [x] `uv run pytest tests/ -v` で全30テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)