### PR TITLE
feat: Phase 3.5 プランをGoogle Calendarに同期

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -205,6 +205,7 @@ flowchart TB
 | **1.5** | カレンダー/天気/大会 + ガードレール | [docs/phase1.5-datasources.md](docs/phase1.5-datasources.md) |
 | **2** | セルフチェック: 別LLM呼び出しでプラン検証 | [docs/phase2-self-check.md](docs/phase2-self-check.md) |
 | **3** | LangGraph: フロー制御移行 | [docs/phase3-langgraph.md](docs/phase3-langgraph.md) |
+| **3.5** | カレンダー同期: プランをGoogle Calendarに登録 | [docs/phase3.5-calendar-sync.md](docs/phase3.5-calendar-sync.md) |
 | **4** | LINE通知: 週次プラン配信 | [docs/phase4-line.md](docs/phase4-line.md) |
 | **5** | Cloud Run + Cloud Scheduler デプロイ | [docs/phase5-cloud-run.md](docs/phase5-cloud-run.md) |
 | **6** | SQLite蓄積 + LLMログ + Decision/Outcome | [docs/phase6-data-logging.md](docs/phase6-data-logging.md) |

--- a/docs/phase3.5-calendar-sync.md
+++ b/docs/phase3.5-calendar-sync.md
@@ -1,0 +1,65 @@
+# Phase 3.5: カレンダー同期
+
+生成したトレーニングプランをGoogle Calendarに自動登録する。
+
+## ゴール
+
+- プラン生成後、ワークアウトをGoogle Calendarの終日イベントとして登録
+- 実行の度にイベントが増殖しない（冪等性）
+- run-coachが作成したイベントを識別可能にする
+
+## フロー
+
+```mermaid
+flowchart LR
+    GEN[プラン生成] --> OUT[Markdown出力]
+    OUT --> DEL[対象期間の<br>run-coachイベント削除]
+    DEL --> INS[ワークアウト<br>イベント挿入]
+
+    style DEL fill:#ff6b6b,color:#fff
+    style INS fill:#51cf66,color:#fff
+```
+
+## イベントの識別
+
+Google Calendar APIの `extendedProperties.private` を使用:
+
+```json
+{"created_by": "run-coach"}
+```
+
+- APIの `privateExtendedProperty` パラメータでフィルタ検索可能
+- ユーザーのカレンダーUIには表示されない内部メタデータ
+
+## 冪等性の担保
+
+1. `week_start` ～ 最終ワークアウト日を対象期間とする
+2. 対象期間内の `created_by=run-coach` イベントを全件削除
+3. 新しいプランのワークアウトを挿入
+
+## イベント構造
+
+| フィールド | 内容 | 例 |
+|--|--|--|
+| summary | `{種目} ({時間}min)` | `テンポ走 (50min)` |
+| start/end | 終日イベント | `2026-03-11` / `2026-03-12` |
+| description | 目的・強度・HR上限・メモ | `目的: 閾値向上\n強度: 高\nHR上限: 165` |
+| extendedProperties | 識別用メタデータ | `{"created_by": "run-coach"}` |
+
+## SCOPESの変更
+
+`calendar.readonly` → `calendar.events`（読み書き）
+
+初回実行時に再認証が必要（`~/.run-coach/token.json` を削除して再実行）。
+
+## 実装
+
+- [x] `run_coach/calendar.py` — `sync_plan_to_calendar()` ノード追加
+- [x] `run_coach/graph.py` — `output_plan → sync_calendar → END`
+- [x] `tests/test_calendar_sync.py` — ユニットテスト
+
+## テスト方針
+
+- `_build_event_body`: イベント構造の正しさ（タイトル、日付、説明、extendedProperties）
+- `_delete_run_coach_events`: 削除APIの呼び出しとフィルタパラメータ
+- `sync_plan_to_calendar`: rest除外、プランなしスキップ、client_secretなしスキップ

--- a/run_coach/calendar.py
+++ b/run_coach/calendar.py
@@ -10,12 +10,12 @@ from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import-un
 from googleapiclient.discovery import Resource, build  # type: ignore[import-untyped]
 from googleapiclient.errors import HttpError  # type: ignore[import-untyped]
 
-from run_coach.state import AgentState, CalendarSlot
+from run_coach.state import AgentState, CalendarSlot, WorkoutPlan
 
 logger = logging.getLogger(__name__)
 
 CALENDAR_LOOKAHEAD_DAYS = 7
-SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
+SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
 RUN_COACH_DIR = Path.home() / ".run-coach"
 TOKEN_PATH = RUN_COACH_DIR / "token.json"
 CLIENT_SECRET_PATH = RUN_COACH_DIR / "client_secret.json"
@@ -108,4 +108,120 @@ def fetch_calendar(state: AgentState) -> AgentState:
         logger.warning("カレンダーの取得に失敗しました", exc_info=True)
 
     print(f"  {len(state.constraints.available_slots)} 日分のスロットを取得しました")
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Phase 3.5: プランをGoogle Calendarに同期
+# ---------------------------------------------------------------------------
+
+EXTENDED_PROPERTY_KEY = "created_by"
+EXTENDED_PROPERTY_VALUE = "run-coach"
+
+WORKOUT_TYPE_LABEL: dict[str, str] = {
+    "easy_run": "イージーラン",
+    "tempo": "テンポ走",
+    "intervals": "インターバル",
+    "long_run": "ロング走",
+    "rest": "休息",
+    "cross_training": "クロストレーニング",
+}
+
+INTENSITY_LABEL: dict[str, str] = {
+    "low": "低",
+    "moderate": "中",
+    "high": "高",
+}
+
+
+def _delete_run_coach_events(service: Resource, time_min: date, time_max: date) -> int:
+    """対象期間内のrun-coachが作成したイベントを削除する。削除件数を返す。"""
+    events_result = (
+        service.events()
+        .list(
+            calendarId="primary",
+            timeMin=f"{time_min}T00:00:00Z",
+            timeMax=f"{time_max}T00:00:00Z",
+            privateExtendedProperty=f"{EXTENDED_PROPERTY_KEY}={EXTENDED_PROPERTY_VALUE}",
+            singleEvents=True,
+        )
+        .execute()
+    )
+
+    deleted_count = 0
+    for event in events_result.get("items", []):
+        service.events().delete(calendarId="primary", eventId=event["id"]).execute()
+        deleted_count += 1
+
+    return deleted_count
+
+
+def _build_event_body(workout: WorkoutPlan) -> dict:
+    """WorkoutPlanからGoogle Calendar APIのイベントボディを構築する。"""
+    workout_label = WORKOUT_TYPE_LABEL.get(workout.workout_type, workout.workout_type)
+    duration = workout.duration_min or 0
+    summary = f"{workout_label} ({duration}min)" if duration else workout_label
+
+    description_parts: list[str] = []
+    if workout.purpose:
+        description_parts.append(f"目的: {workout.purpose}")
+    if workout.intensity:
+        intensity_label = INTENSITY_LABEL.get(workout.intensity, workout.intensity)
+        description_parts.append(f"強度: {intensity_label}")
+    if workout.max_hr:
+        description_parts.append(f"HR上限: {workout.max_hr}")
+    if workout.notes:
+        description_parts.append(workout.notes)
+
+    end_date = workout.date + timedelta(days=1)
+
+    return {
+        "summary": summary,
+        "start": {"date": str(workout.date)},
+        "end": {"date": str(end_date)},
+        "description": "\n".join(description_parts),
+        "extendedProperties": {
+            "private": {EXTENDED_PROPERTY_KEY: EXTENDED_PROPERTY_VALUE}
+        },
+    }
+
+
+def _create_workout_event(service: Resource, workout: WorkoutPlan) -> None:
+    """WorkoutPlanをGoogle Calendarにイベントとして作成する。"""
+    body = _build_event_body(workout)
+    service.events().insert(calendarId="primary", body=body).execute()
+
+
+def sync_plan_to_calendar(state: AgentState) -> AgentState:
+    """LangGraphノード: プランのワークアウトをGoogle Calendarに同期する。"""
+    if not state.plan:
+        return state
+
+    print("カレンダーにプランを同期中...")
+
+    if not CLIENT_SECRET_PATH.exists():
+        logger.info("client_secret.jsonが未配置のためカレンダー同期をスキップします")
+        return state
+
+    workouts_to_sync = [w for w in state.plan.workouts if w.workout_type != "rest"]
+    if not workouts_to_sync:
+        print("  同期対象のワークアウトがありません")
+        return state
+
+    try:
+        service = _get_calendar_service()
+
+        time_min = state.plan.week_start
+        time_max = max(w.date for w in state.plan.workouts) + timedelta(days=1)
+        deleted_count = _delete_run_coach_events(service, time_min, time_max)
+        if deleted_count:
+            print(f"  既存のイベント {deleted_count} 件を削除しました")
+
+        for workout in workouts_to_sync:
+            _create_workout_event(service, workout)
+
+        print(f"  {len(workouts_to_sync)} 件のワークアウトをカレンダーに登録しました")
+    except (HttpError, OSError, ValueError):
+        logger.warning("カレンダーへの同期に失敗しました", exc_info=True)
+
     return state

--- a/run_coach/graph.py
+++ b/run_coach/graph.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
-from run_coach.calendar import fetch_calendar
+from run_coach.calendar import fetch_calendar, sync_plan_to_calendar
 from run_coach.formatter import output_plan
 from run_coach.garmin import fetch_races, fetch_workouts
 from run_coach.plan_review import self_check
@@ -32,6 +32,7 @@ def build_graph() -> StateGraph:
     graph.add_node("generate_plan", generate_plan)
     graph.add_node("self_check", self_check)
     graph.add_node("output_plan", output_plan)
+    graph.add_node("sync_calendar", sync_plan_to_calendar)
 
     graph.add_edge(START, "fetch_workouts")
     graph.add_edge("fetch_workouts", "fetch_races")
@@ -44,7 +45,8 @@ def build_graph() -> StateGraph:
         _should_continue,
         {"ok": "output_plan", "ng": "generate_plan"},
     )
-    graph.add_edge("output_plan", END)
+    graph.add_edge("output_plan", "sync_calendar")
+    graph.add_edge("sync_calendar", END)
 
     return graph
 

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_coach.calendar import (
+    EXTENDED_PROPERTY_KEY,
+    EXTENDED_PROPERTY_VALUE,
+    _build_event_body,
+    _delete_run_coach_events,
+    sync_plan_to_calendar,
+)
+from run_coach.state import (
+    AgentState,
+    Plan,
+    UserProfile,
+    RunsPerWeek,
+    WorkoutPlan,
+)
+
+
+def _make_state(workouts: list[WorkoutPlan] | None = None) -> AgentState:
+    """テスト用のAgentStateを生成する。"""
+    profile = UserProfile(
+        birthday=date(1990, 1, 1),
+        goal="サブ4",
+        runs_per_week=RunsPerWeek(min=3, max=5),
+    )
+    plan = None
+    if workouts is not None:
+        plan = Plan(
+            week_start=date(2026, 3, 9),
+            workout_evaluation="良好",
+            workouts=workouts,
+            load_summary="週3回",
+            reasoning="テスト用",
+        )
+    return AgentState(user_profile=profile, plan=plan)
+
+
+@pytest.fixture()
+def sample_workouts() -> list[WorkoutPlan]:
+    return [
+        WorkoutPlan(
+            date=date(2026, 3, 9),
+            workout_type="easy_run",
+            purpose="疲労抜き",
+            duration_min=40,
+            intensity="low",
+            max_hr=140,
+            notes="",
+        ),
+        WorkoutPlan(
+            date=date(2026, 3, 10),
+            workout_type="rest",
+            purpose="",
+            duration_min=0,
+            intensity="low",
+        ),
+        WorkoutPlan(
+            date=date(2026, 3, 11),
+            workout_type="tempo",
+            purpose="閾値向上",
+            duration_min=50,
+            intensity="high",
+            max_hr=165,
+            notes="4:30/kmで20分",
+        ),
+    ]
+
+
+class TestBuildEventBody:
+    def test_basic_event(self) -> None:
+        workout = WorkoutPlan(
+            date=date(2026, 3, 9),
+            workout_type="easy_run",
+            purpose="疲労抜き",
+            duration_min=40,
+            intensity="low",
+            max_hr=140,
+            notes="",
+        )
+        body = _build_event_body(workout)
+
+        assert body["summary"] == "イージーラン (40min)"
+        assert body["start"] == {"date": "2026-03-09"}
+        assert body["end"] == {"date": "2026-03-10"}
+        assert "目的: 疲労抜き" in body["description"]
+        assert "強度: 低" in body["description"]
+        assert "HR上限: 140" in body["description"]
+        assert (
+            body["extendedProperties"]["private"][EXTENDED_PROPERTY_KEY]
+            == EXTENDED_PROPERTY_VALUE
+        )
+
+    def test_event_with_notes(self) -> None:
+        workout = WorkoutPlan(
+            date=date(2026, 3, 11),
+            workout_type="tempo",
+            purpose="閾値向上",
+            duration_min=50,
+            intensity="high",
+            max_hr=165,
+            notes="4:30/kmで20分",
+        )
+        body = _build_event_body(workout)
+
+        assert body["summary"] == "テンポ走 (50min)"
+        assert "4:30/kmで20分" in body["description"]
+
+    def test_unknown_workout_type_uses_raw_value(self) -> None:
+        workout = WorkoutPlan(
+            date=date(2026, 3, 9),
+            workout_type="hill_repeats",
+            duration_min=30,
+        )
+        body = _build_event_body(workout)
+
+        assert body["summary"] == "hill_repeats (30min)"
+
+    def test_zero_duration(self) -> None:
+        workout = WorkoutPlan(
+            date=date(2026, 3, 9),
+            workout_type="cross_training",
+            duration_min=0,
+        )
+        body = _build_event_body(workout)
+
+        assert body["summary"] == "クロストレーニング"
+
+    def test_no_optional_fields(self) -> None:
+        workout = WorkoutPlan(
+            date=date(2026, 3, 9),
+            workout_type="easy_run",
+            intensity=None,
+        )
+        body = _build_event_body(workout)
+
+        assert body["summary"] == "イージーラン"
+        assert body["description"] == ""
+
+
+class TestDeleteRunCoachEvents:
+    def test_deletes_matching_events(self) -> None:
+        mock_service = MagicMock()
+        mock_events = mock_service.events.return_value
+        mock_events.list.return_value.execute.return_value = {
+            "items": [
+                {"id": "event1"},
+                {"id": "event2"},
+            ]
+        }
+
+        deleted = _delete_run_coach_events(
+            mock_service, date(2026, 3, 9), date(2026, 3, 16)
+        )
+
+        assert deleted == 2
+        assert mock_events.delete.call_count == 2
+        mock_events.delete.assert_any_call(calendarId="primary", eventId="event1")
+        mock_events.delete.assert_any_call(calendarId="primary", eventId="event2")
+
+    def test_no_events_to_delete(self) -> None:
+        mock_service = MagicMock()
+        mock_events = mock_service.events.return_value
+        mock_events.list.return_value.execute.return_value = {"items": []}
+
+        deleted = _delete_run_coach_events(
+            mock_service, date(2026, 3, 9), date(2026, 3, 16)
+        )
+
+        assert deleted == 0
+        mock_events.delete.assert_not_called()
+
+    def test_uses_extended_property_filter(self) -> None:
+        mock_service = MagicMock()
+        mock_events = mock_service.events.return_value
+        mock_events.list.return_value.execute.return_value = {"items": []}
+
+        _delete_run_coach_events(mock_service, date(2026, 3, 9), date(2026, 3, 16))
+
+        mock_events.list.assert_called_once_with(
+            calendarId="primary",
+            timeMin="2026-03-09T00:00:00Z",
+            timeMax="2026-03-16T00:00:00Z",
+            privateExtendedProperty=f"{EXTENDED_PROPERTY_KEY}={EXTENDED_PROPERTY_VALUE}",
+            singleEvents=True,
+        )
+
+
+class TestSyncPlanToCalendar:
+    @patch("run_coach.calendar._get_calendar_service")
+    @patch("run_coach.calendar.CLIENT_SECRET_PATH")
+    def test_syncs_non_rest_workouts(
+        self,
+        mock_path: MagicMock,
+        mock_get_service: MagicMock,
+        sample_workouts: list[WorkoutPlan],
+    ) -> None:
+        mock_path.exists.return_value = True
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+        mock_events = mock_service.events.return_value
+        mock_events.list.return_value.execute.return_value = {"items": []}
+
+        state = _make_state(sample_workouts)
+        result = sync_plan_to_calendar(state)
+
+        assert result.plan is not None
+        # rest以外の2件がinsertされること
+        assert mock_events.insert.return_value.execute.call_count == 2
+
+    @patch("run_coach.calendar._get_calendar_service")
+    @patch("run_coach.calendar.CLIENT_SECRET_PATH")
+    def test_skips_when_no_plan(
+        self, mock_path: MagicMock, mock_get_service: MagicMock
+    ) -> None:
+        mock_path.exists.return_value = True
+        state = _make_state(workouts=None)
+        result = sync_plan_to_calendar(state)
+
+        mock_get_service.assert_not_called()
+        assert result.plan is None
+
+    @patch("run_coach.calendar.CLIENT_SECRET_PATH")
+    def test_skips_when_no_client_secret(
+        self, mock_path: MagicMock, sample_workouts: list[WorkoutPlan]
+    ) -> None:
+        mock_path.exists.return_value = False
+        state = _make_state(sample_workouts)
+        result = sync_plan_to_calendar(state)
+
+        assert result.plan is not None
+
+    @patch("run_coach.calendar._get_calendar_service")
+    @patch("run_coach.calendar.CLIENT_SECRET_PATH")
+    def test_deletes_before_insert(
+        self,
+        mock_path: MagicMock,
+        mock_get_service: MagicMock,
+        sample_workouts: list[WorkoutPlan],
+    ) -> None:
+        mock_path.exists.return_value = True
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+        mock_events = mock_service.events.return_value
+        mock_events.list.return_value.execute.return_value = {
+            "items": [{"id": "old_event"}]
+        }
+
+        state = _make_state(sample_workouts)
+        sync_plan_to_calendar(state)
+
+        # deleteがinsertより先に呼ばれること
+        mock_events.delete.assert_called_once_with(
+            calendarId="primary", eventId="old_event"
+        )
+        mock_events.delete.return_value.execute.assert_called_once()
+
+    @patch("run_coach.calendar._get_calendar_service")
+    @patch("run_coach.calendar.CLIENT_SECRET_PATH")
+    def test_all_rest_skips_sync(
+        self, mock_path: MagicMock, mock_get_service: MagicMock
+    ) -> None:
+        mock_path.exists.return_value = True
+        rest_only = [
+            WorkoutPlan(date=date(2026, 3, 9), workout_type="rest"),
+        ]
+        state = _make_state(rest_only)
+        result = sync_plan_to_calendar(state)
+
+        mock_get_service.assert_not_called()
+        assert result.plan is not None


### PR DESCRIPTION
## Summary

- 生成したトレーニングプランをGoogle Calendarの終日イベントとして自動登録
- `extendedProperties.private` でrun-coach製イベントを識別し、挿入前に対象期間の既存イベントを削除（冪等性）
- restの日はカレンダーに登録しない

## 変更内容

- `run_coach/calendar.py`: スコープを `calendar.events` に変更、`sync_plan_to_calendar` ノード追加
- `run_coach/graph.py`: `output_plan → sync_calendar → END` のフロー追加
- `docs/phase3.5-calendar-sync.md`: 設計ドキュメント
- `DESIGN.md`: フェーズ計画にPhase 3.5を追加
- `tests/test_calendar_sync.py`: 13テスト追加

## Test plan

- [x] `uv run pytest tests/` — 全43テスト通過
- [x] `uv run python -m run_coach` — 実行してGoogle Calendarにイベントが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)