### PR TITLE
fix: plan_review_max_retriesの設定値が反映されない問題を修正

### DIFF
--- a/run_coach/graph.py
+++ b/run_coach/graph.py
@@ -7,7 +7,7 @@ from run_coach.calendar import fetch_calendar, sync_plan_to_calendar
 from run_coach.formatter import output_plan
 from run_coach.garmin import fetch_races, fetch_workouts
 from run_coach.plan_review import self_check
-from run_coach.planner import PLAN_REVIEW_MAX_RETRIES, generate_plan
+from run_coach import planner
 from run_coach.state import AgentState
 from run_coach.weather import fetch_weather
 
@@ -16,7 +16,7 @@ def _should_continue(state: AgentState) -> str:
     """self_check後のルーティング判定。"""
     if state.review_result == "ok":
         return "ok"
-    if state.review_retry_count > PLAN_REVIEW_MAX_RETRIES:
+    if state.review_retry_count > planner.PLAN_REVIEW_MAX_RETRIES:
         return "ok"
     return "ng"
 
@@ -29,7 +29,7 @@ def build_graph() -> StateGraph:
     graph.add_node("fetch_races", fetch_races)
     graph.add_node("fetch_calendar", fetch_calendar)
     graph.add_node("fetch_weather", fetch_weather)
-    graph.add_node("generate_plan", generate_plan)
+    graph.add_node("generate_plan", planner.generate_plan)
     graph.add_node("self_check", self_check)
     graph.add_node("output_plan", output_plan)
     graph.add_node("sync_calendar", sync_plan_to_calendar)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,8 @@
 import json
 from datetime import date
 
+from run_coach import planner
 from run_coach.graph import _should_continue, compile_graph
-from run_coach.planner import PLAN_REVIEW_MAX_RETRIES
 from run_coach.state import (
     AgentState,
     Plan,
@@ -98,7 +98,7 @@ def test_conditional_edge_max_retries():
     """リトライ上限超過で 'ok'（強制終了）になること。"""
     state = _make_state()
     state.review_result = "ng"
-    state.review_retry_count = PLAN_REVIEW_MAX_RETRIES + 1
+    state.review_retry_count = planner.PLAN_REVIEW_MAX_RETRIES + 1
     assert _should_continue(state) == "ok"
 
 
@@ -123,7 +123,7 @@ def test_graph_full_flow(monkeypatch):
     monkeypatch.setattr("run_coach.graph.fetch_races", noop)
     monkeypatch.setattr("run_coach.graph.fetch_calendar", noop)
     monkeypatch.setattr("run_coach.graph.fetch_weather", noop)
-    monkeypatch.setattr("run_coach.graph.generate_plan", mock_generate_plan)
+    monkeypatch.setattr("run_coach.planner.generate_plan", mock_generate_plan)
     monkeypatch.setattr("run_coach.graph.self_check", mock_self_check)
     monkeypatch.setattr("run_coach.graph.output_plan", noop)
 
@@ -163,7 +163,7 @@ def test_graph_retry_flow(monkeypatch):
     monkeypatch.setattr("run_coach.graph.fetch_races", noop)
     monkeypatch.setattr("run_coach.graph.fetch_calendar", noop)
     monkeypatch.setattr("run_coach.graph.fetch_weather", noop)
-    monkeypatch.setattr("run_coach.graph.generate_plan", mock_generate_plan)
+    monkeypatch.setattr("run_coach.planner.generate_plan", mock_generate_plan)
     monkeypatch.setattr("run_coach.graph.self_check", mock_self_check)
     monkeypatch.setattr("run_coach.graph.output_plan", noop)
 


### PR DESCRIPTION
## Summary
- `graph.py`で`from run_coach.planner import PLAN_REVIEW_MAX_RETRIES`としていたため、インポート時のデフォルト値(2)がコピーされ、`settings.yaml`で設定した値が反映されなかった
- モジュール参照(`planner.PLAN_REVIEW_MAX_RETRIES`)に変更し、実行時の最新値を参照するように修正
- テストのmonkeypatchパス・インポートも同様に修正

## Test plan
- [x] `uv run pytest tests/` 全43テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)