### PR TITLE
feat: Phase 4.5 workout_splitsラップデータ蓄積

### DIFF
--- a/PLAN_phase4.5_workout_splits.md
+++ b/PLAN_phase4.5_workout_splits.md
@@ -1,0 +1,63 @@
+# Phase 4.5: workout_splits（ラップデータ蓄積）実装計画
+
+## Context
+
+Phase 4（SQLite + Garmin振り返り）が完了し、workoutsテーブルにワークアウトのサマリーデータを蓄積できるようになった。
+Phase 4.5では `client.get_activity_splits(activity_id)` でラップデータを取得し、
+`workout_splits`テーブルに蓄積する。
+
+## Garmin API調査結果
+
+`GET /activity-service/activity/{id}/splits` のレスポンス:
+
+```json
+{
+  "activityId": 22111745238,
+  "lapDTOs": [
+    {
+      "distance": 1000.0,       // メートル
+      "duration": 588.802,      // 秒
+      "elevationGain": 6.0,     // メートル
+      "averageHR": 105.0,       // bpm
+      "maxHR": 119.0,           // bpm
+      "lapIndex": 1,            // 1始まり
+      "averageSpeed": 1.698,    // m/s
+      "intensityType": "ACTIVE"
+    }
+  ]
+}
+```
+
+## 実装手順
+
+### Step 1: database.py — workout_splitsテーブル + CRUD
+
+- `_CREATE_SPLITS_TABLE`: テーブル定義
+- `init_db()`: 既存のworkoutsテーブル作成に加えてsplitsテーブルも作成
+- `save_splits(conn, workout_id, splits_list)`: ラップ一括保存
+- `get_splits_by_workout_id(conn, workout_id)`: ラップ取得
+
+### Step 2: garmin.py — splits取得・パース
+
+- `fetch_activity_splits(client, activity_id)`: APIからsplits取得 → dict list変換
+- ペース計算: `duration / (distance / 1000)` → "M:SS"形式
+
+### Step 3: workout_store.py — splits保存統合
+
+- `save_workouts()` ノード内で、新規保存したワークアウトのsplitsも取得・保存
+- Garmin APIコール追加（`_login()` でクライアント取得）
+
+### Step 4: テスト
+
+- `test_database.py`: splits CRUD、workoutとの紐付け、重複排除
+- `test_garmin.py`: parse_splits のユニットテスト
+
+## 変更対象ファイル
+
+| ファイル | 変更種別 |
+|----------|----------|
+| `run_coach/database.py` | 変更 |
+| `run_coach/garmin.py` | 変更 |
+| `run_coach/workout_store.py` | 変更 |
+| `tests/test_database.py` | 変更 |
+| `tests/test_garmin.py` | 変更 |

--- a/run_coach/converters.py
+++ b/run_coach/converters.py
@@ -1,0 +1,19 @@
+"""ペース等の単位変換ユーティリティ。"""
+
+from __future__ import annotations
+
+
+def pace_str_to_seconds(pace: str) -> float:
+    """ペース文字列 "5:30" を秒/km (330.0) に変換する。"""
+    parts = pace.split(":")
+    return int(parts[0]) * 60 + int(parts[1])
+
+
+def pace_seconds_to_str(duration_sec: float, distance_km: float) -> str:
+    """ラップタイム(秒)と距離(km)からペース文字列 "M:SS" に変換する。"""
+    if distance_km <= 0:
+        return "0:00"
+    pace_s_per_km = duration_sec / distance_km
+    pace_min = int(pace_s_per_km // 60)
+    pace_sec = int(pace_s_per_km % 60)
+    return f"{pace_min}:{pace_sec:02d}"

--- a/run_coach/database.py
+++ b/run_coach/database.py
@@ -31,6 +31,21 @@ CREATE TABLE IF NOT EXISTS workouts (
 );
 """
 
+_CREATE_SPLITS_TABLE = """\
+CREATE TABLE IF NOT EXISTS workout_splits (
+    id              INTEGER PRIMARY KEY,
+    workout_id      INTEGER REFERENCES workouts(id),
+    split_number    INTEGER,              -- ラップ番号 (1始まり)
+    distance_km     REAL,                 -- ラップ距離 (km)
+    duration_sec    REAL,                 -- ラップタイム (秒)
+    avg_pace        TEXT,                 -- 平均ペース (例: "5:30")
+    avg_hr          INTEGER,              -- 平均心拍数 (bpm)
+    max_hr          INTEGER,              -- 最大心拍数 (bpm)
+    elevation_gain  REAL,                 -- 獲得標高 (m)
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
 _INSERT_WORKOUT = """\
 INSERT OR IGNORE INTO workouts (
     garmin_activity_id, date, workout_type, distance_km,
@@ -74,16 +89,33 @@ def get_connection(db_path: Path | None = None) -> sqlite3.Connection:
     return conn
 
 
+_INSERT_SPLIT = """\
+INSERT INTO workout_splits (
+    workout_id, split_number, distance_km,
+    duration_sec, avg_pace, avg_hr, max_hr, elevation_gain
+) VALUES (
+    :workout_id, :split_number, :distance_km,
+    :duration_sec, :avg_pace, :avg_hr, :max_hr, :elevation_gain
+);
+"""
+
+
 def init_db(conn: sqlite3.Connection) -> None:
     """テーブルを作成する（存在しなければ）。"""
     conn.execute(_CREATE_WORKOUTS_TABLE)
+    conn.execute(_CREATE_SPLITS_TABLE)
     conn.commit()
 
 
-def save_workout(conn: sqlite3.Connection, workout_dict: dict) -> None:
-    """ワークアウトを保存する。garmin_activity_idが重複する場合は無視（INSERT OR IGNORE）。"""
-    conn.execute(_INSERT_WORKOUT, workout_dict)
+def save_workout(conn: sqlite3.Connection, workout_dict: dict) -> int | None:
+    """ワークアウトを保存する。garmin_activity_idが重複する場合は無視（INSERT OR IGNORE）。
+
+    Returns:
+        挿入された行のID。重複スキップ時はNone。
+    """
+    cursor = conn.execute(_INSERT_WORKOUT, workout_dict)
     conn.commit()
+    return cursor.lastrowid if cursor.rowcount > 0 else None
 
 
 def update_workout_feedback(
@@ -110,7 +142,8 @@ def get_unsaved_activity_ids(
         return []
     placeholders = ",".join("?" for _ in garmin_activity_ids)
     cursor = conn.execute(
-        f"SELECT garmin_activity_id FROM workouts WHERE garmin_activity_id IN ({placeholders})",  # noqa: S608
+        f"SELECT garmin_activity_id FROM workouts "  # noqa: S608
+        f"WHERE garmin_activity_id IN ({placeholders})",
         garmin_activity_ids,
     )
     saved_ids = {row["garmin_activity_id"] for row in cursor}
@@ -139,3 +172,38 @@ def get_workout_by_garmin_id(
     )
     row = cursor.fetchone()
     return dict(row) if row else None
+
+
+def save_splits(conn: sqlite3.Connection, workout_id: int, splits: list[dict]) -> None:
+    """ラップデータをバルクインサートで一括保存する。既存データがあればスキップ。"""
+    cursor = conn.execute(
+        "SELECT COUNT(*) as cnt FROM workout_splits WHERE workout_id = ?",
+        (workout_id,),
+    )
+    if cursor.fetchone()["cnt"] > 0:
+        return
+
+    params_list = [
+        {
+            "workout_id": workout_id,
+            "split_number": split["split_number"],
+            "distance_km": split["distance_km"],
+            "duration_sec": split["duration_sec"],
+            "avg_pace": split["avg_pace"],
+            "avg_hr": split.get("avg_hr"),
+            "max_hr": split.get("max_hr"),
+            "elevation_gain": split.get("elevation_gain"),
+        }
+        for split in splits
+    ]
+    conn.executemany(_INSERT_SPLIT, params_list)
+    conn.commit()
+
+
+def get_splits_by_workout_id(conn: sqlite3.Connection, workout_id: int) -> list[dict]:
+    """workout_idに紐づくラップデータを取得する。"""
+    cursor = conn.execute(
+        "SELECT * FROM workout_splits WHERE workout_id = ? ORDER BY split_number",
+        (workout_id,),
+    )
+    return [dict(row) for row in cursor]

--- a/run_coach/garmin.py
+++ b/run_coach/garmin.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from garminconnect import Garmin, GarminConnectAuthenticationError  # type: ignore[import-untyped]
 
+from run_coach.converters import pace_seconds_to_str
 from run_coach.state import AgentState, RaceEvent, Signals, WorkoutSummary
 
 logger = logging.getLogger(__name__)
@@ -95,6 +96,53 @@ def summarize_activity(activity: dict) -> WorkoutSummary | None:
         garmin_activity_id=str(activity.get("activityId", "")),
         description=activity.get("description", ""),
     )
+
+
+def parse_splits(raw_splits: dict) -> list[dict]:
+    """Garmin splits APIレスポンスをパースし、ラップデータのリストに変換する。
+
+    Args:
+        raw_splits: client.get_activity_splits() の戻り値
+
+    Returns:
+        ラップごとの辞書リスト。各辞書は split_number, distance_km,
+        duration_sec, avg_pace, avg_hr, max_hr, elevation_gain を含む。
+    """
+    laps = raw_splits.get("lapDTOs", [])
+    result: list[dict] = []
+    for lap in laps:
+        distance_m = lap.get("distance", 0) or 0
+        duration_sec = lap.get("duration", 0) or 0
+        distance_km = round(distance_m / 1000, 3)
+        avg_pace = pace_seconds_to_str(duration_sec, distance_km)
+
+        result.append(
+            {
+                "split_number": lap.get("lapIndex", len(result) + 1),
+                "distance_km": distance_km,
+                "duration_sec": round(duration_sec, 1),
+                "avg_pace": avg_pace,
+                "avg_hr": int(lap["averageHR"]) if lap.get("averageHR") else None,
+                "max_hr": int(lap["maxHR"]) if lap.get("maxHR") else None,
+                "elevation_gain": lap.get("elevationGain"),
+            }
+        )
+    return result
+
+
+def fetch_activity_splits(activity_id: str) -> list[dict]:
+    """Garmin ConnectからアクティビティのラップデータをAPI取得してパースする。"""
+    client = _login()
+    try:
+        raw_splits = client.get_activity_splits(activity_id)
+        if not isinstance(raw_splits, dict):
+            return []
+        return parse_splits(raw_splits)
+    except (KeyError, TypeError, OSError):
+        logger.warning(
+            "ラップデータの取得に失敗: activity_id=%s", activity_id, exc_info=True
+        )
+        return []
 
 
 def fetch_workouts(state: AgentState) -> AgentState:

--- a/run_coach/workout_store.py
+++ b/run_coach/workout_store.py
@@ -4,21 +4,27 @@ from __future__ import annotations
 
 import logging
 
+from run_coach.converters import pace_str_to_seconds
 from run_coach.database import (
     get_connection,
     get_unsaved_activity_ids,
+    save_splits,
     save_workout,
 )
 from run_coach.feedback_parser import parse_description
+from run_coach.garmin import fetch_activity_splits
 from run_coach.state import AgentState
 
 logger = logging.getLogger(__name__)
 
 
-def _pace_str_to_seconds(pace: str) -> float:
-    """ペース文字列 "5:30" を秒/km (330.0) に変換する。"""
-    parts = pace.split(":")
-    return int(parts[0]) * 60 + int(parts[1])
+def _save_activity_splits(conn, workout_id: int, activity_id: str) -> int:
+    """ラップデータをGarminから取得して保存する。保存ラップ数を返す。"""
+    splits = fetch_activity_splits(activity_id)
+    if not splits:
+        return 0
+    save_splits(conn, workout_id, splits)
+    return len(splits)
 
 
 def save_workouts(state: AgentState) -> AgentState:
@@ -41,6 +47,7 @@ def save_workouts(state: AgentState) -> AgentState:
         unsaved_ids = set(get_unsaved_activity_ids(conn, all_ids))
 
         saved_count = 0
+        splits_count = 0
         for workout in workouts_with_id:
             activity_id = workout.garmin_activity_id
             assert activity_id is not None  # workouts_with_idでフィルタ済み
@@ -57,7 +64,7 @@ def save_workouts(state: AgentState) -> AgentState:
                 "workout_type": workout.type,
                 "distance_km": workout.distance_km,
                 "duration_min": workout.duration_min,
-                "pace_seconds_per_km": _pace_str_to_seconds(workout.avg_pace),
+                "pace_seconds_per_km": pace_str_to_seconds(workout.avg_pace),
                 "avg_heart_rate_bpm": workout.avg_hr,
                 "training_effect": workout.training_effect,
                 "description": description,
@@ -65,10 +72,13 @@ def save_workouts(state: AgentState) -> AgentState:
                 "pain": feedback["pain"],
                 "comment": feedback["comment"],
             }
-            save_workout(conn, workout_dict)
+            workout_id = save_workout(conn, workout_dict)
+            if workout_id is None:
+                continue
             saved_count += 1
+            splits_count += _save_activity_splits(conn, workout_id, activity_id)
 
-        print(f"  SQLite: {saved_count}件保存")
+        print(f"  SQLite: {saved_count}件保存 ({splits_count}ラップ)")
     finally:
         conn.close()
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,10 +4,12 @@ import pytest
 
 from run_coach.database import (
     get_connection,
+    get_splits_by_workout_id,
     get_unsaved_activity_ids,
     get_workout_by_garmin_id,
     get_workout_history,
     init_db,
+    save_splits,
     save_workout,
     update_workout_feedback,
 )
@@ -114,3 +116,78 @@ def test_get_workout_history(db):
 def test_get_workout_by_garmin_id_not_found(db):
     """存在しないIDはNoneを返すこと。"""
     assert get_workout_by_garmin_id(db, "nonexistent") is None
+
+
+# --- workout_splits テスト ---
+
+
+def _make_splits(count: int = 3) -> list[dict]:
+    """テスト用のラップデータリストを生成する。"""
+    return [
+        {
+            "split_number": i + 1,
+            "distance_km": 1.0,
+            "duration_sec": 330.0 - i * 5,
+            "avg_pace": f"5:{30 - i * 5:02d}",
+            "avg_hr": 140 + i * 5,
+            "max_hr": 150 + i * 5,
+            "elevation_gain": 3.0 + i,
+        }
+        for i in range(count)
+    ]
+
+
+def test_save_and_get_splits(db):
+    """ラップデータの保存・取得ができること。"""
+    save_workout(db, _make_workout())
+    workout = get_workout_by_garmin_id(db, "123")
+    assert workout is not None
+
+    splits = _make_splits(2)
+    save_splits(db, workout["id"], splits)
+
+    result = get_splits_by_workout_id(db, workout["id"])
+    assert len(result) == 2
+    assert result[0]["split_number"] == 1
+    assert result[0]["avg_pace"] == "5:30"
+    assert result[0]["avg_hr"] == 140
+    assert result[1]["split_number"] == 2
+    assert result[1]["avg_pace"] == "5:25"
+
+
+def test_splits_no_duplicate(db):
+    """同一workout_idのsplitsを重複保存しないこと。"""
+    save_workout(db, _make_workout())
+    workout = get_workout_by_garmin_id(db, "123")
+    assert workout is not None
+
+    splits = _make_splits(2)
+    save_splits(db, workout["id"], splits)
+    save_splits(db, workout["id"], splits)  # 2回目はスキップされる
+
+    result = get_splits_by_workout_id(db, workout["id"])
+    assert len(result) == 2
+
+
+def test_splits_linked_to_workout(db):
+    """workout_idで正しく紐付けされること。"""
+    save_workout(db, _make_workout(garmin_activity_id="A1"))
+    save_workout(db, _make_workout(garmin_activity_id="A2"))
+
+    w1 = get_workout_by_garmin_id(db, "A1")
+    w2 = get_workout_by_garmin_id(db, "A2")
+    assert w1 is not None and w2 is not None
+
+    save_splits(db, w1["id"], _make_splits(3))
+    save_splits(db, w2["id"], _make_splits(1))
+
+    assert len(get_splits_by_workout_id(db, w1["id"])) == 3
+    assert len(get_splits_by_workout_id(db, w2["id"])) == 1
+
+
+def test_get_splits_empty(db):
+    """splitsがないworkoutは空リストを返すこと。"""
+    save_workout(db, _make_workout())
+    workout = get_workout_by_garmin_id(db, "123")
+    assert workout is not None
+    assert get_splits_by_workout_id(db, workout["id"]) == []

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1,4 +1,4 @@
-from run_coach.garmin import summarize_activity
+from run_coach.garmin import parse_splits, summarize_activity
 
 
 def _make_activity(**overrides) -> dict:
@@ -37,3 +37,76 @@ def test_summarize_zero_distance():
     result = summarize_activity(_make_activity(distance=0))
     assert result is not None
     assert result.avg_pace == "0:00"
+
+
+# --- parse_splits テスト ---
+
+
+def _make_raw_splits(*laps) -> dict:
+    """Garmin splits APIレスポンスのモックを生成する。"""
+    return {"activityId": 12345, "lapDTOs": list(laps)}
+
+
+def _make_lap(**overrides) -> dict:
+    """ラップデータのモックを生成する。"""
+    base = {
+        "distance": 1000.0,  # 1km in meters
+        "duration": 330.0,  # 5:30 in seconds
+        "elevationGain": 5.0,
+        "averageHR": 145.0,
+        "maxHR": 160.0,
+        "lapIndex": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parse_splits_basic():
+    """基本的なラップデータのパースが正しいこと"""
+    raw = _make_raw_splits(
+        _make_lap(
+            lapIndex=1, distance=1000.0, duration=330.0, averageHR=140.0, maxHR=155.0
+        ),
+        _make_lap(
+            lapIndex=2, distance=1000.0, duration=320.0, averageHR=148.0, maxHR=162.0
+        ),
+    )
+    result = parse_splits(raw)
+    assert len(result) == 2
+    assert result[0]["split_number"] == 1
+    assert result[0]["distance_km"] == 1.0
+    assert result[0]["duration_sec"] == 330.0
+    assert result[0]["avg_pace"] == "5:30"
+    assert result[0]["avg_hr"] == 140
+    assert result[0]["max_hr"] == 155
+
+    assert result[1]["split_number"] == 2
+    assert result[1]["avg_pace"] == "5:20"
+
+
+def test_parse_splits_partial_lap():
+    """端数ラップ（1km未満）が正しくパースされること"""
+    raw = _make_raw_splits(
+        _make_lap(lapIndex=1, distance=1000.0, duration=300.0),
+        _make_lap(lapIndex=2, distance=500.0, duration=160.0),  # 0.5km
+    )
+    result = parse_splits(raw)
+    assert len(result) == 2
+    assert result[1]["distance_km"] == 0.5
+    assert result[1]["avg_pace"] == "5:20"  # 160 / 0.5 = 320 sec/km = 5:20
+
+
+def test_parse_splits_empty():
+    """空のレスポンスでも動くこと"""
+    assert parse_splits({}) == []
+    assert parse_splits({"lapDTOs": []}) == []
+
+
+def test_parse_splits_missing_hr():
+    """心拍データがないラップでNoneになること"""
+    raw = _make_raw_splits(
+        _make_lap(lapIndex=1, averageHR=None, maxHR=None),
+    )
+    result = parse_splits(raw)
+    assert result[0]["avg_hr"] is None
+    assert result[0]["max_hr"] is None


### PR DESCRIPTION
## Summary

- `workout_splits`テーブル追加（1km毎のラップデータ蓄積）
- Garmin splits API (`get_activity_splits`) のレスポンスパース機能追加
- ワークアウト保存時にラップも自動取得・保存する統合処理
- ペース変換関数を`converters.py`に集約（`pace_str_to_seconds` / `pace_seconds_to_str`）
- `save_workout()`が`lastrowid`を返すように改善（再取得の無駄を排除）

## Test plan

- [x] splits CRUD: 保存・取得・重複排除・紐付け（4テスト）
- [x] parse_splits: 基本パース・端数ラップ・空レスポンス・HR欠損（4テスト）
- [x] 既存テスト全68件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)