### PR TITLE
feat: Phase 5.1 ワークアウト保存をバルクupsertに変更

### DIFF
--- a/docs/phase5.1-upsert.md
+++ b/docs/phase5.1-upsert.md
@@ -1,0 +1,86 @@
+# Phase 5.1: ワークアウト Upsert 対応
+
+## 目的
+
+Garmin上でワークアウトのコメント（description）を後から修正した場合に、DBへ反映されるようにする。
+
+`ON CONFLICT DO NOTHING` → `ON CONFLICT DO UPDATE`（upsert）に変更し、Garmin側の変更をDBに同期する。
+また、1件ずつINSERTしていたワークアウト保存をバルクupsertに変更し、DB往復を削減する。
+
+## 変更内容
+
+### 1. `upsert_workouts()` — バルクupsert（`database.py`）
+
+旧 `save_workout()` (1件ずつ) → `upsert_workouts()` (一括) にリネーム・バルク化。
+
+```python
+def upsert_workouts(conn, workout_dicts: list[dict]) -> dict[str, int]:
+    """ワークアウトをバルクupsertで保存する。
+    Returns: {garmin_activity_id: workout_id} のマッピング。
+    """
+    stmt = insert(workouts).values(workout_dicts)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["garmin_activity_id"],
+        set_={...},  # 更新対象カラム
+    ).returning(workouts.c.id, workouts.c.garmin_activity_id)
+```
+
+**更新対象カラム:**
+
+| カラム | 更新する | 理由 |
+|--------|----------|------|
+| `date` | No | 変わらない |
+| `workout_type` | No | 変わらない |
+| `distance_km` | Yes | Garmin側で手動補正の可能性 |
+| `duration_min` | Yes | 同上 |
+| `pace_seconds_per_km` | Yes | distance/durationから再計算 |
+| `avg_heart_rate_bpm` | Yes | Garmin側補正の可能性 |
+| `training_effect` | Yes | 同上 |
+| `description` | Yes | **主目的: コメント修正の反映** |
+| `rpe` | Yes | descriptionパース結果 |
+| `pain` | Yes | descriptionパース結果 |
+| `comment` | Yes | descriptionパース結果 |
+| `created_at` | No | 初回登録日時を保持 |
+
+### 2. `save_splits()` → upsert化（`database.py`）
+
+splitsもGarmin側で再計算される可能性があるため、`on_conflict_do_update` に変更。
+（元々バルクインサートだったため、バルクupsertへの変更のみ）
+
+### 3. `save_workouts()` ノードの簡素化（`workout_store.py`）
+
+- ループで1件ずつ `upsert_workout()` → `upsert_workouts()` で一括処理
+- `get_unsaved_activity_ids()` による事前フィルタを削除（upsertで不要）
+- 戻り値の `id_map` を使ってsplits保存をループ
+
+```python
+# Before: N回のDB往復
+for workout in workouts_with_id:
+    workout_id = upsert_workout(conn, workout_dict)
+    _save_activity_splits(conn, workout_id, activity_id)
+
+# After: 1回のバルクupsert + N回のsplits取得
+workout_dicts = [build_dict(w) for w in workouts_with_id]
+id_map = upsert_workouts(conn, workout_dicts)
+for activity_id, workout_id in id_map.items():
+    _save_activity_splits(conn, workout_id, activity_id)
+```
+
+### 4. 削除した関数
+
+| 関数 | 理由 |
+|------|------|
+| `get_unsaved_activity_ids()` | upsertで不要 |
+| `update_workout_feedback()` | upsertでdescriptionごと更新されるため不要 |
+
+## テスト
+
+- バルクupsert（複数件の一括保存）
+- 空リストの処理
+- 同一 `garmin_activity_id` で2回保存 → 2回目の値で更新
+- `created_at`, `date`, `workout_type` が更新されないこと
+- splits の upsert: 同じ `(workout_id, split_number)` で更新
+
+## マイグレーション
+
+スキーマ変更なし（ON CONFLICTの動作はアプリ側の変更のみ）。

--- a/run_coach/database.py
+++ b/run_coach/database.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from datetime import date, timedelta
 
-from sqlalchemy import Connection, Engine, create_engine, select, text, update
+from sqlalchemy import Connection, Engine, create_engine, select, text
 from sqlalchemy.dialects.postgresql import insert
 
 from run_coach.models import metadata, workout_splits, workouts
@@ -93,53 +93,37 @@ def create_tables(engine: Engine) -> None:
     metadata.create_all(engine)
 
 
-def save_workout(conn: Connection, workout_dict: dict) -> int | None:
-    """ワークアウトを保存する。garmin_activity_idが重複する場合は無視。
+def upsert_workouts(conn: Connection, workout_dicts: list[dict]) -> dict[str, int]:
+    """ワークアウトをバルクupsertで保存する。
+
+    garmin_activity_idが既存の場合はGarmin側の変更を反映（description修正等）。
+    date, workout_type, created_at は初回登録値を保持する。
 
     Returns:
-        挿入された行のID。重複スキップ時はNone。
+        {garmin_activity_id: workout_id} のマッピング。
     """
-    stmt = (
-        insert(workouts)
-        .values(**workout_dict)
-        .on_conflict_do_nothing(index_elements=["garmin_activity_id"])
-        .returning(workouts.c.id)
+    if not workout_dicts:
+        return {}
+    insert_stmt = insert(workouts).values(workout_dicts)
+    conflict_stmt = insert_stmt.on_conflict_do_update(
+        index_elements=["garmin_activity_id"],
+        set_={
+            "distance_km": insert_stmt.excluded.distance_km,
+            "duration_min": insert_stmt.excluded.duration_min,
+            "pace_seconds_per_km": insert_stmt.excluded.pace_seconds_per_km,
+            "avg_heart_rate_bpm": insert_stmt.excluded.avg_heart_rate_bpm,
+            "training_effect": insert_stmt.excluded.training_effect,
+            "description": insert_stmt.excluded.description,
+            "rpe": insert_stmt.excluded.rpe,
+            "pain": insert_stmt.excluded.pain,
+            "comment": insert_stmt.excluded.comment,
+        },
     )
-    result = conn.execute(stmt)
-    row = result.fetchone()
-    return row[0] if row else None
-
-
-def update_workout_feedback(
-    conn: Connection,
-    garmin_activity_id: str,
-    feedback_dict: dict,
-) -> None:
-    """振り返り情報（rpe/pain/comment）を更新する。"""
-    stmt = (
-        update(workouts)
-        .where(workouts.c.garmin_activity_id == garmin_activity_id)
-        .values(
-            rpe=feedback_dict.get("rpe"),
-            pain=feedback_dict.get("pain"),
-            comment=feedback_dict.get("comment"),
-        )
+    returning_stmt = conflict_stmt.returning(
+        workouts.c.id, workouts.c.garmin_activity_id
     )
-    conn.execute(stmt)
-
-
-def get_unsaved_activity_ids(
-    conn: Connection, garmin_activity_ids: list[str]
-) -> list[str]:
-    """渡されたIDのうち、まだDBに保存されていないものを返す。"""
-    if not garmin_activity_ids:
-        return []
-    stmt = select(workouts.c.garmin_activity_id).where(
-        workouts.c.garmin_activity_id.in_(garmin_activity_ids)
-    )
-    result = conn.execute(stmt)
-    saved_ids = {row[0] for row in result}
-    return [aid for aid in garmin_activity_ids if aid not in saved_ids]
+    rows = conn.execute(returning_stmt).fetchall()
+    return {row.garmin_activity_id: row.id for row in rows}
 
 
 def get_workout_history(
@@ -164,7 +148,7 @@ def get_workout_by_garmin_id(conn: Connection, garmin_activity_id: str) -> dict 
 
 
 def save_splits(conn: Connection, workout_id: int, splits: list[dict]) -> None:
-    """ラップデータをバルクインサートで一括保存する。重複はスキップ。"""
+    """ラップデータをupsertで一括保存する。既存データは最新値で更新。"""
     if not splits:
         return
     rows = [
@@ -180,12 +164,19 @@ def save_splits(conn: Connection, workout_id: int, splits: list[dict]) -> None:
         }
         for s in splits
     ]
-    stmt = (
-        insert(workout_splits)
-        .values(rows)
-        .on_conflict_do_nothing(constraint="workout_splits_workout_id_split_number_key")
+    insert_stmt = insert(workout_splits).values(rows)
+    upsert_stmt = insert_stmt.on_conflict_do_update(
+        constraint="workout_splits_workout_id_split_number_key",
+        set_={
+            "distance_km": insert_stmt.excluded.distance_km,
+            "duration_sec": insert_stmt.excluded.duration_sec,
+            "avg_pace": insert_stmt.excluded.avg_pace,
+            "avg_hr": insert_stmt.excluded.avg_hr,
+            "max_hr": insert_stmt.excluded.max_hr,
+            "elevation_gain": insert_stmt.excluded.elevation_gain,
+        },
     )
-    conn.execute(stmt)
+    conn.execute(upsert_stmt)
 
 
 def get_splits_by_workout_id(conn: Connection, workout_id: int) -> list[dict]:

--- a/run_coach/workout_store.py
+++ b/run_coach/workout_store.py
@@ -7,9 +7,8 @@ import logging
 from run_coach.converters import pace_str_to_seconds
 from run_coach.database import (
     get_engine,
-    get_unsaved_activity_ids,
     save_splits,
-    save_workout,
+    upsert_workouts,
 )
 from run_coach.feedback_parser import parse_description
 from run_coach.garmin import fetch_activity_splits
@@ -28,10 +27,10 @@ def _save_activity_splits(conn, workout_id: int, activity_id: str) -> int:
 
 
 def save_workouts(state: AgentState) -> AgentState:
-    """ワークアウトをPostgreSQLに保存する。
+    """ワークアウトをPostgreSQLにupsertで保存する。
 
     descriptionがあればパースしてrpe/pain/commentも一緒に保存する。
-    garmin_activity_idが重複する場合はスキップ（ON CONFLICT DO NOTHING）。
+    garmin_activity_idが既存の場合はGarmin側の変更を反映する。
     """
     workouts = state.signals.recent_workouts
     if not workouts:
@@ -41,44 +40,34 @@ def save_workouts(state: AgentState) -> AgentState:
     with engine.connect() as conn:
         workouts_with_id = [w for w in workouts if w.garmin_activity_id]
 
-        all_ids = [
-            w.garmin_activity_id for w in workouts_with_id if w.garmin_activity_id
-        ]
-        unsaved_ids = set(get_unsaved_activity_ids(conn, all_ids))
-
-        saved_count = 0
-        splits_count = 0
+        workout_dicts = []
         for workout in workouts_with_id:
-            activity_id = workout.garmin_activity_id
-            assert activity_id is not None  # workouts_with_idでフィルタ済み
-
-            if activity_id not in unsaved_ids:
-                continue
-
             description = workout.description or ""
             feedback = parse_description(description)
+            workout_dicts.append(
+                {
+                    "garmin_activity_id": workout.garmin_activity_id,
+                    "date": workout.date,
+                    "workout_type": workout.type,
+                    "distance_km": workout.distance_km,
+                    "duration_min": workout.duration_min,
+                    "pace_seconds_per_km": pace_str_to_seconds(workout.avg_pace),
+                    "avg_heart_rate_bpm": workout.avg_hr,
+                    "training_effect": workout.training_effect,
+                    "description": description,
+                    "rpe": feedback["rpe"],
+                    "pain": feedback["pain"],
+                    "comment": feedback["comment"],
+                }
+            )
 
-            workout_dict = {
-                "garmin_activity_id": activity_id,
-                "date": workout.date,
-                "workout_type": workout.type,
-                "distance_km": workout.distance_km,
-                "duration_min": workout.duration_min,
-                "pace_seconds_per_km": pace_str_to_seconds(workout.avg_pace),
-                "avg_heart_rate_bpm": workout.avg_hr,
-                "training_effect": workout.training_effect,
-                "description": description,
-                "rpe": feedback["rpe"],
-                "pain": feedback["pain"],
-                "comment": feedback["comment"],
-            }
-            workout_id = save_workout(conn, workout_dict)
-            if workout_id is None:
-                continue
-            saved_count += 1
+        id_map = upsert_workouts(conn, workout_dicts)
+
+        splits_count = 0
+        for activity_id, workout_id in id_map.items():
             splits_count += _save_activity_splits(conn, workout_id, activity_id)
 
         conn.commit()
-        print(f"  DB: {saved_count}件保存 ({splits_count}ラップ)")
+        print(f"  DB: {len(id_map)}件upsert ({splits_count}ラップ)")
 
     return state

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,10 +28,13 @@ def clean_db(_setup_tables):
     """save_workouts()ノードテスト用fixture。
 
     ノードが自前でcommitするため通常のrollback fixtureでは隔離できない。
-    teardownでTRUNCATEを必ず実行する。
+    setup/teardownでTRUNCATEを実行する。
     """
-    yield
     engine = get_engine()
+    with engine.connect() as conn:
+        conn.execute(text("TRUNCATE workout_splits, workouts CASCADE"))
+        conn.commit()
+    yield
     with engine.connect() as conn:
         conn.execute(text("TRUNCATE workout_splits, workouts CASCADE"))
         conn.commit()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,12 +2,10 @@ from datetime import date, timedelta
 
 from run_coach.database import (
     get_splits_by_workout_id,
-    get_unsaved_activity_ids,
     get_workout_by_garmin_id,
     get_workout_history,
     save_splits,
-    save_workout,
-    update_workout_feedback,
+    upsert_workouts,
 )
 
 
@@ -30,9 +28,16 @@ def _make_workout(**overrides) -> dict:
     return base
 
 
+def _upsert_one(db, **overrides) -> int:
+    """テスト用ヘルパー: 1件upsertしてworkout_idを返す。"""
+    workout = _make_workout(**overrides)
+    id_map = upsert_workouts(db, [workout])
+    return id_map[workout["garmin_activity_id"]]
+
+
 def test_save_and_get_workout(db):
     """保存・取得ができること。"""
-    save_workout(db, _make_workout())
+    _upsert_one(db)
     result = get_workout_by_garmin_id(db, "123")
     assert result is not None
     assert result["distance_km"] == 10.0
@@ -41,19 +46,83 @@ def test_save_and_get_workout(db):
     assert result["date"] == date(2026, 3, 1)
 
 
-def test_no_duplicate_workout(db):
-    """garmin_activity_id重複時にエラーにならないこと。"""
-    save_workout(db, _make_workout())
-    save_workout(db, _make_workout())  # 2回目
+def test_upsert_workouts_bulk(db):
+    """複数件を一括upsertできること。"""
+    workout_dicts = [
+        _make_workout(garmin_activity_id="A1", distance_km=5.0),
+        _make_workout(garmin_activity_id="A2", distance_km=10.0),
+        _make_workout(garmin_activity_id="A3", distance_km=15.0),
+    ]
+    id_map = upsert_workouts(db, workout_dicts)
+    assert set(id_map.keys()) == {"A1", "A2", "A3"}
+
+    w1 = get_workout_by_garmin_id(db, "A1")
+    w3 = get_workout_by_garmin_id(db, "A3")
+    assert w1 is not None and w1["distance_km"] == 5.0
+    assert w3 is not None and w3["distance_km"] == 15.0
+
+
+def test_upsert_workouts_empty(db):
+    """空リストを渡しても動くこと。"""
+    id_map = upsert_workouts(db, [])
+    assert id_map == {}
+
+
+def test_upsert_workout_updates_fields(db):
+    """同一garmin_activity_idで2回保存すると、2回目の値で更新されること。"""
+    _upsert_one(db, description="初回コメント", comment="初回")
+    _upsert_one(db, description="修正コメント", comment="修正後")
+
+    result = get_workout_by_garmin_id(db, "123")
+    assert result is not None
+    assert result["description"] == "修正コメント"
+    assert result["comment"] == "修正後"
+
+
+def test_upsert_workout_no_duplicate(db):
+    """upsert後もレコード数は1件であること。"""
+    _upsert_one(db)
+    _upsert_one(db, distance_km=12.0)
+
     from sqlalchemy import text
 
-    row = db.execute(text("SELECT count(*) as cnt FROM workouts")).fetchone()
+    row = db.execute(
+        text("SELECT count(*) FROM workouts WHERE garmin_activity_id = '123'")
+    ).fetchone()
     assert row[0] == 1
 
+    result = get_workout_by_garmin_id(db, "123")
+    assert result is not None
+    assert result["distance_km"] == 12.0
 
-def test_save_workout_with_feedback(db):
+
+def test_upsert_workout_preserves_created_at(db):
+    """upsertでcreated_atが変わらないこと。"""
+    _upsert_one(db)
+    original = get_workout_by_garmin_id(db, "123")
+    assert original is not None
+
+    _upsert_one(db, description="更新")
+    updated = get_workout_by_garmin_id(db, "123")
+    assert updated is not None
+
+    assert original["created_at"] == updated["created_at"]
+
+
+def test_upsert_workout_preserves_date_and_type(db):
+    """upsertでdate, workout_typeは初回値が保持されること。"""
+    _upsert_one(db, date="2026-03-01", workout_type="running")
+    _upsert_one(db, date="2026-03-02", workout_type="trail_running")
+
+    result = get_workout_by_garmin_id(db, "123")
+    assert result is not None
+    assert result["date"] == date(2026, 3, 1)
+    assert result["workout_type"] == "running"
+
+
+def test_upsert_workout_with_feedback(db):
     """振り返り付きで保存できること。"""
-    save_workout(db, _make_workout(rpe=7, pain="右ひざ", comment="調子良かった"))
+    _upsert_one(db, rpe=7, pain="右ひざ", comment="調子良かった")
     result = get_workout_by_garmin_id(db, "123")
     assert result is not None
     assert result["rpe"] == 7
@@ -61,39 +130,12 @@ def test_save_workout_with_feedback(db):
     assert result["comment"] == "調子良かった"
 
 
-def test_update_workout_feedback(db):
-    """rpe/pain/commentが更新されること。"""
-    save_workout(db, _make_workout())
-    update_workout_feedback(
-        db, "123", {"rpe": 7, "pain": None, "comment": "調子良かった"}
-    )
-    result = get_workout_by_garmin_id(db, "123")
-    assert result is not None
-    assert result["rpe"] == 7
-    assert result["pain"] is None
-    assert result["comment"] == "調子良かった"
-
-
-def test_get_unsaved_activity_ids(db):
-    """未保存分のIDが正しく検出されること。"""
-    save_workout(db, _make_workout(garmin_activity_id="100"))
-    save_workout(db, _make_workout(garmin_activity_id="200"))
-
-    unsaved = get_unsaved_activity_ids(db, ["100", "200", "300", "400"])
-    assert sorted(unsaved) == ["300", "400"]
-
-
-def test_get_unsaved_activity_ids_empty(db):
-    """空リストを渡しても動くこと。"""
-    assert get_unsaved_activity_ids(db, []) == []
-
-
 def test_get_workout_history(db):
     """期間指定で取得できること。"""
     today = date.today()
-    save_workout(db, _make_workout(garmin_activity_id="recent", date=today.isoformat()))
+    _upsert_one(db, garmin_activity_id="recent", date=today.isoformat())
     old_date = today - timedelta(days=100)
-    save_workout(db, _make_workout(garmin_activity_id="old", date=old_date.isoformat()))
+    _upsert_one(db, garmin_activity_id="old", date=old_date.isoformat())
 
     history = get_workout_history(db, days=90)
     ids = [w["garmin_activity_id"] for w in history]
@@ -127,14 +169,12 @@ def _make_splits(count: int = 3) -> list[dict]:
 
 def test_save_and_get_splits(db):
     """ラップデータの保存・取得ができること。"""
-    save_workout(db, _make_workout())
-    workout = get_workout_by_garmin_id(db, "123")
-    assert workout is not None
+    workout_id = _upsert_one(db)
 
     splits = _make_splits(2)
-    save_splits(db, workout["id"], splits)
+    save_splits(db, workout_id, splits)
 
-    result = get_splits_by_workout_id(db, workout["id"])
+    result = get_splits_by_workout_id(db, workout_id)
     assert len(result) == 2
     assert result[0]["split_number"] == 1
     assert result[0]["avg_pace"] == "5:30"
@@ -143,39 +183,73 @@ def test_save_and_get_splits(db):
     assert result[1]["avg_pace"] == "5:25"
 
 
+def test_upsert_splits(db):
+    """同一(workout_id, split_number)で2回保存すると更新されること。"""
+    workout_id = _upsert_one(db)
+
+    splits_v1 = [
+        {
+            "split_number": 1,
+            "distance_km": 1.0,
+            "duration_sec": 300.0,
+            "avg_pace": "5:00",
+            "avg_hr": 140,
+            "max_hr": 150,
+            "elevation_gain": 3.0,
+        },
+    ]
+    save_splits(db, workout_id, splits_v1)
+
+    splits_v2 = [
+        {
+            "split_number": 1,
+            "distance_km": 1.0,
+            "duration_sec": 290.0,
+            "avg_pace": "4:50",
+            "avg_hr": 145,
+            "max_hr": 155,
+            "elevation_gain": 4.0,
+        },
+    ]
+    save_splits(db, workout_id, splits_v2)
+
+    result = get_splits_by_workout_id(db, workout_id)
+    assert len(result) == 1
+    assert result[0]["duration_sec"] == 290.0
+    assert result[0]["avg_pace"] == "4:50"
+    assert result[0]["avg_hr"] == 145
+
+
 def test_splits_no_duplicate(db):
-    """同一workout_idのsplitsを重複保存しないこと。"""
-    save_workout(db, _make_workout())
-    workout = get_workout_by_garmin_id(db, "123")
-    assert workout is not None
+    """同一workout_idのsplitsを重複保存してもレコード数が増えないこと。"""
+    workout_id = _upsert_one(db)
 
     splits = _make_splits(2)
-    save_splits(db, workout["id"], splits)
-    save_splits(db, workout["id"], splits)  # 2回目はスキップされる
+    save_splits(db, workout_id, splits)
+    save_splits(db, workout_id, splits)  # 2回目はupsert
 
-    result = get_splits_by_workout_id(db, workout["id"])
+    result = get_splits_by_workout_id(db, workout_id)
     assert len(result) == 2
 
 
 def test_splits_linked_to_workout(db):
     """workout_idで正しく紐付けされること。"""
-    save_workout(db, _make_workout(garmin_activity_id="A1"))
-    save_workout(db, _make_workout(garmin_activity_id="A2"))
+    id_map = upsert_workouts(
+        db,
+        [
+            _make_workout(garmin_activity_id="A1"),
+            _make_workout(garmin_activity_id="A2"),
+        ],
+    )
 
-    w1 = get_workout_by_garmin_id(db, "A1")
-    w2 = get_workout_by_garmin_id(db, "A2")
-    assert w1 is not None and w2 is not None
+    save_splits(db, id_map["A1"], _make_splits(3))
+    save_splits(db, id_map["A2"], _make_splits(1))
 
-    save_splits(db, w1["id"], _make_splits(3))
-    save_splits(db, w2["id"], _make_splits(1))
-
-    assert len(get_splits_by_workout_id(db, w1["id"])) == 3
-    assert len(get_splits_by_workout_id(db, w2["id"])) == 1
+    assert len(get_splits_by_workout_id(db, id_map["A1"])) == 3
+    assert len(get_splits_by_workout_id(db, id_map["A2"])) == 1
 
 
 def test_get_splits_empty(db):
     """splitsがないworkoutは空リストを返すこと。"""
-    save_workout(db, _make_workout())
-    workout = get_workout_by_garmin_id(db, "123")
-    assert workout is not None
-    assert get_splits_by_workout_id(db, workout["id"]) == []
+    workout_id = _upsert_one(db)
+    assert get_splits_by_workout_id(db, workout_id) == []

--- a/tests/test_workout_store.py
+++ b/tests/test_workout_store.py
@@ -93,13 +93,13 @@ def test_save_workouts_node(monkeypatch, clean_db):
         assert split_count[0] == 4  # 2ワークアウト × 2ラップ
 
 
-def test_save_workouts_skip_duplicate(monkeypatch, clean_db):
-    """既に保存済みのワークアウトはスキップされること。"""
+def test_save_workouts_upsert_no_duplicate(monkeypatch, clean_db):
+    """同一ワークアウトを2回保存してもレコード数は1件のままであること。"""
     monkeypatch.setattr("run_coach.workout_store.fetch_activity_splits", _mock_splits)
 
     state = _make_state("ACT001")
     save_workouts(state)
-    save_workouts(state)  # 2回目
+    save_workouts(state)  # 2回目（upsert）
 
     engine = get_engine()
     with engine.connect() as conn:


### PR DESCRIPTION
## Summary

- ワークアウト保存を `ON CONFLICT DO NOTHING` → `ON CONFLICT DO UPDATE` に変更し、Garmin側のdescription修正がDBに反映されるようにした
- 1件ずつのINSERTをバルクupsert (`upsert_workouts()`) に変更してDB往復を削減
- 不要になった `get_unsaved_activity_ids()` / `update_workout_feedback()` を削除

## Test plan

- [x] `uv run pytest tests/test_database.py tests/test_workout_store.py -v` 全17テスト通過
- [ ] Garminでdescription修正後にrun-coach実行してDB反映を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)