### PR TITLE
docs: Phase 6をPhase 6.1〜6.4に分割

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,6 +82,8 @@ uv add --dev <package>
 ### 必須
 - **mainブランチに直接コミットしない。必ずブランチを切ってPRで統合する**
 - シークレットをハードコードしない（`.zprofile`の環境変数 / Secret Manager）
+- `.env` ファイルは使わない。環境変数はシェル設定ファイルで管理する
+- アプリケーション設定（ポート番号等）は `config/settings.yaml` で管理する
 - LLMに送るデータは最小限（位置情報・個人情報を除外）
 - Pydanticでstateスキーマを定義（型安全）
 - LLM出力は構造化JSON（文章ではなくPlan型に準拠）

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -222,15 +222,27 @@ flowchart LR
         P5[+ PostgreSQL移行<br>+ Supabase前提のDB構成]
     end
 
-    subgraph Phase6[Phase 6]
-        P6[+ Cloud Run<br>+ Cloud Scheduler<br>+ 自動実行]
+    subgraph Phase61[Phase 6.1]
+        P61[+ Dockerfile<br>+ FastAPI<br>+ Docker Compose]
+    end
+
+    subgraph Phase62[Phase 6.2]
+        P62[+ Cloud Run<br>+ Secret Manager<br>+ Supabase接続]
+    end
+
+    subgraph Phase63[Phase 6.3]
+        P63[+ Cloud Scheduler<br>+ IAM認証<br>+ 自動実行]
+    end
+
+    subgraph Phase64[Phase 6.4]
+        P64[+ Terraform<br>+ インフラコード化<br>+ 別リポジトリ]
     end
 
     subgraph Phase7[Phase 7]
         P7[+ LINE通知<br>+ 週次プラン配信<br>+ 振り返り対話]
     end
 
-    Phase1 --> Phase15 --> Phase2 --> Phase3 --> Phase35 --> Phase4 --> Phase45 --> Phase5 --> Phase6 --> Phase7
+    Phase1 --> Phase15 --> Phase2 --> Phase3 --> Phase35 --> Phase4 --> Phase45 --> Phase5 --> Phase61 --> Phase62 --> Phase63 --> Phase64 --> Phase7
 ```
 
 ### 本番構成 (Phase 6: Cloud Run + Phase 7: LINE)
@@ -270,7 +282,10 @@ flowchart TB
 | **4** | データ蓄積: SQLite + Garmin振り返り + Decision/Outcome | [docs/phase4-data-logging.md](docs/phase4-data-logging.md) |
 | **4.5** | workout_splits: 1km毎のラップデータ蓄積 | [docs/phase4.5-workout-splits.md](docs/phase4.5-workout-splits.md) |
 | **5** | PostgreSQL移行: ローカル/本番のDB構成を統一 | [docs/phase5-postgres.md](docs/phase5-postgres.md) |
-| **6** | Cloud Run + Cloud Scheduler デプロイ | [docs/phase6-cloud-run.md](docs/phase6-cloud-run.md) |
+| **6.1** | Dockerfile + ローカルDocker実行 | [docs/phase6.1-docker-local.md](docs/phase6.1-docker-local.md) |
+| **6.2** | Cloud Run デプロイ + Secret Manager | [docs/phase6.2-cloud-run-deploy.md](docs/phase6.2-cloud-run-deploy.md) |
+| **6.3** | Cloud Scheduler + 自動実行 | [docs/phase6.3-cloud-scheduler.md](docs/phase6.3-cloud-scheduler.md) |
+| **6.4** | Terraform インフラ管理（別リポジトリ） | [docs/phase6.4-terraform.md](docs/phase6.4-terraform.md) |
 | **7** | LINE通知 + 振り返り対話 | [docs/phase7-line.md](docs/phase7-line.md) |
 
 ## Stateスキーマ（Pydantic）
@@ -596,10 +611,11 @@ def summarize_activity(activity):
 ### おすすめの追加順
 
 ```
-Phase 3.5完了後（現在地）
-  → Phase 4: データ蓄積（SQLite + Garmin振り返り + Decision/Outcome）
-  → Phase 5: PostgreSQL移行（ローカル / 本番DB統一）
-  → Phase 6: Cloud Run（自動実行）
+Phase 5完了後（現在地）
+  → Phase 6.1: Dockerfile + ローカルDocker実行
+  → Phase 6.2: Cloud Run デプロイ + Secret Manager
+  → Phase 6.3: Cloud Scheduler + 自動実行
+  → Phase 6.4: Terraform インフラ管理（別リポジトリ）
   → Phase 7: LINE通知 + 振り返り対話
 ```
 

--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -2,3 +2,4 @@ llm_model: "gpt-4o-mini"  # OpenAI model name (e.g. gpt-4o, gpt-4o-mini, o3-mini
 plan_review_max_retries: 2  # セルフチェックNGの場合の再生成回数上限
 debug: false  # trueでLLM生成プラン・レビュー結果を出力
 db_port: 5433  # PostgreSQLホスト側ポート（コンテナ内部は常に5432）
+app_port: 8080  # FastAPIホスト側ポート（コンテナ内部は常に8080）

--- a/docs/phase6.1-docker-local.md
+++ b/docs/phase6.1-docker-local.md
@@ -1,0 +1,96 @@
+# Phase 6.1: Dockerfile + ローカルDocker実行
+
+ローカルでDockerコンテナとしてrun-coachを動かせる状態にする。
+
+## ゴール
+
+`docker compose up` でプラン生成が動く状態にする。Cloud Runデプロイ（Phase 6.2）の前提基盤。
+
+## 前提
+
+- Phase 5 でPostgreSQL移行が完了していること
+- ローカルにDockerがインストール済みであること
+
+## やること
+
+### Dockerfile
+
+- [ ] マルチステージビルド（uvベース）
+- [ ] Python + 依存パッケージのインストール
+- [ ] `run_coach/` と `config/` をコピー
+- [ ] FastAPIをuvicornで起動
+
+### FastAPIアプリ
+
+- [ ] `run_coach/api.py` 作成
+- [ ] `POST /generate` — LangGraphのプラン生成を実行
+- [ ] `GET /health` — ヘルスチェック
+
+```python
+@app.post("/generate")
+async def generate() -> dict:
+    """プラン生成を実行"""
+    ...
+
+@app.get("/health")
+async def health() -> dict:
+    return {"ok": True}
+```
+
+### docker-compose.yml
+
+- [ ] `app` サービス（run-coachコンテナ）
+- [ ] `db` サービス（PostgreSQL）
+- [ ] 環境変数はホストの `.zprofile` から `environment` で渡す
+- [ ] ボリューム設定（DBデータ永続化）
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: run_coach
+      POSTGRES_PASSWORD: run_coach
+      POSTGRES_DB: run_coach
+    ports:
+      - "${DB_PORT:-5433}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  app:
+    build: .
+    ports:
+      - "${APP_PORT:-8080}:8080"
+    environment:
+      - DATABASE_URL=postgresql://run_coach:run_coach@db:5432/run_coach
+      - GARMIN_EMAIL=${GARMIN_EMAIL}
+      - GARMIN_PASSWORD=${GARMIN_PASSWORD}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    depends_on:
+      - db
+
+volumes:
+  pgdata:
+```
+
+※ `DB_PORT` / `APP_PORT` は `config/settings.yaml` の値を使う。docker-compose起動時に渡す。
+
+### 環境変数
+
+ホストの `.zprofile` で定義済みの環境変数を `docker compose` が自動で展開する（`${VAR}` 構文）。追加の設定ファイルは不要。
+
+## テスト方針
+
+- [ ] `docker compose up` でコンテナが起動すること
+- [ ] `GET /health` が `{"ok": true}` を返すこと
+- [ ] `POST /generate` でプラン生成が実行されること
+- [ ] 既存テスト（Phase 1〜5）がコンテナ内でも通ること
+- [ ] DB接続: コンテナ内からPostgreSQLにワークアウトデータを読み書きできること
+
+## 対象外（Phase 6.2以降）
+
+- Cloud Runデプロイ
+- Secret Manager
+- Cloud Scheduler
+- サービスアカウント認証
+- Garminトークンのステートレス対応

--- a/docs/phase6.2-cloud-run-deploy.md
+++ b/docs/phase6.2-cloud-run-deploy.md
@@ -1,0 +1,81 @@
+# Phase 6.2: Cloud Run デプロイ + Secret Manager
+
+Cloud Runにデプロイし、本番環境で動作する状態にする。
+
+## ゴール
+
+Cloud Run上でプラン生成APIが動く状態にする。Phase 6.3（自動実行）の前提基盤。
+
+## 前提
+
+- Phase 6.1 でDockerコンテナがローカルで動作すること
+- GCPプロジェクトが作成済みであること
+- Supabase PostgreSQL が利用できること
+
+## やること
+
+### Cloud Run デプロイ
+
+- [ ] Cloud Runサービスのデプロイ（`gcloud run deploy`）
+- [ ] 未認証リクエストを拒否する設定
+- [ ] リージョン: `asia-northeast1`
+
+```bash
+gcloud run deploy run-coach \
+  --source . \
+  --region asia-northeast1 \
+  --allow-unauthenticated=false
+```
+
+### Secret Manager
+
+- [ ] `GARMIN_EMAIL` / `GARMIN_PASSWORD`
+- [ ] `OPENAI_API_KEY`
+- [ ] `DATABASE_URL`（Supabase接続文字列）
+- [ ] Cloud Runから環境変数として注入
+
+### DB接続
+
+- [ ] Supabase PostgreSQL への接続設定
+- [ ] transaction pooler を優先（prepared statements前提を避ける）
+- [ ] `DATABASE_URL` で接続先を管理
+
+### Google Calendar認証（Workload Identity）
+
+- [ ] run-coach専用カレンダーを個人アカウントで作成
+- [ ] Cloud Runのサービスアカウントに専用カレンダーの編集権限を共有
+- [ ] Workload Identityで認証（キーファイル不要）
+- [ ] コード側で環境に応じて認証を切り替え（ローカル: OAuth / Cloud Run: `google.auth.default()`）
+- [ ] 専用カレンダーのIDを `config/settings.yaml` で管理
+
+### Garmin認証（GCSトークン保存方式）
+
+Cloud Runはステートレスなので `~/.garminconnect` のトークン保存方式が使えない。
+GCSにトークンを保存し、起動時に復元する方式を採用する。
+
+- [ ] GCSバケット作成（トークン保存用）
+- [ ] 起動時にGCSからトークンを取得 → `/tmp` に復元
+- [ ] トークンで認証（期限切れ時はパスワードでフォールバック）
+- [ ] 認証後、更新されたトークンをGCSに書き戻し
+- [ ] Cloud Runのサービスアカウントにバケットの読み書き権限を付与
+
+```
+起動時: GCSからトークン取得 → /tmpに復元
+  ↓
+認証: トークンで認証（期限切れならパスワードでフォールバック）
+  ↓
+終了時: 更新されたトークンをGCSに書き戻し
+```
+
+## テスト方針
+
+- [ ] Cloud Run上で `/health` が応答すること
+- [ ] Secret Managerから認証情報を取得できること
+- [ ] Supabase PostgreSQL に接続して `workouts` / `workout_splits` を読めること
+- [ ] `/generate` でプラン生成が実行されること
+
+## 対象外（Phase 6.3）
+
+- Cloud Scheduler
+- 自動実行（週次トリガー）
+- リトライ / 障害対応

--- a/docs/phase6.3-cloud-scheduler.md
+++ b/docs/phase6.3-cloud-scheduler.md
@@ -1,0 +1,62 @@
+# Phase 6.3: Cloud Scheduler + 自動実行
+
+Cloud Schedulerで週次プラン生成を自動実行する。
+
+## ゴール
+
+Macを閉じていても自動でプラン生成が動く状態にする。Phase 7（LINE通知）の前提基盤。
+
+## 前提
+
+- Phase 6.2 でCloud Run上にプラン生成APIがデプロイ済みであること
+
+## フロー
+
+```mermaid
+flowchart TB
+    CS[Cloud Scheduler<br>毎週月曜朝] -->|HTTP + OIDC| CR
+
+    subgraph CR[Cloud Run: run-coach]
+        FG[fetch_garmin] --> FC[fetch_calendar<br>Google Calendar API]
+        FG --> DB[(Supabase<br>PostgreSQL)]
+        FC --> FW[fetch_weather]
+        FW --> GR[ガードレール]
+        GR --> GEN[LLM: プラン生成]
+        GEN --> CHK[セルフチェック]
+        CHK -->|OK| OUT[output_plan<br>+ Calendar同期]
+        CHK -->|NG| GEN
+    end
+
+    OUT -.->|Phase 7| LINE[LINE Push通知]
+
+    style CS fill:#4a9eff,color:#fff
+    style CR fill:#f5f5f5,color:#333
+```
+
+## やること
+
+### Cloud Scheduler
+
+- [ ] ジョブ作成（毎週月曜朝にHTTPリクエスト）
+- [ ] ターゲット: Cloud Runの `/generate` エンドポイント
+- [ ] タイムゾーン: `Asia/Tokyo`
+
+### IAM認証
+
+- [ ] Cloud SchedulerにCloud Run起動権限を付与
+- [ ] OIDCトークンでの認証設定
+- [ ] 未認証リクエストの拒否を確認
+
+### リトライ / 障害対応
+
+- [ ] Cloud Scheduler側でHTTP失敗時のリトライ設定
+- [ ] Garmin API / LLM APIの一時的失敗はアプリ側で短いリトライ
+- [ ] 部分失敗時はログを残し、再実行できるようにする
+- [ ] DB接続失敗時は `500` を返し、Schedulerに再試行させる
+
+## テスト方針
+
+- [ ] Cloud Scheduler → Cloud Run のE2Eテスト
+- [ ] IAM認証が正しく機能すること（認証なしリクエストが拒否されること）
+- [ ] リトライが正しく動作すること
+- [ ] 週次実行でプラン生成 → Calendar同期が完了すること

--- a/docs/phase6.4-terraform.md
+++ b/docs/phase6.4-terraform.md
@@ -1,0 +1,60 @@
+# Phase 6.4: Terraform によるインフラ管理
+
+GCPリソースをTerraformでコード管理する。リポジトリは `run-coach` とは別のプライベートリポジトリで管理する。
+
+## ゴール
+
+GCPインフラの構成をコード化し、再現可能な状態にする。
+
+## 前提
+
+- Phase 6.1〜6.3 で手動構築したGCPリソースが動作していること
+
+## 別リポジトリ構成
+
+```
+run-coach-infra/          # プライベートリポジトリ
+├── main.tf
+├── variables.tf
+├── outputs.tf
+├── modules/
+│   ├── cloud-run/
+│   ├── cloud-scheduler/
+│   ├── secret-manager/
+│   ├── gcs/
+│   └── iam/
+└── .gitignore
+```
+
+### run-coachリポジトリと分ける理由
+
+- インフラ変更とアプリ変更のライフサイクルが異なる
+- プライベートリポジトリで権限を厳格に管理できる
+
+### シークレット管理方針
+
+- TerraformではSecret Managerの**リソース（箱）だけ**を管理する
+- シークレットの**値**はTerraformで管理しない（`gcloud` CLIで手動設定）
+
+## 管理対象リソース
+
+| リソース | 用途 |
+|---------|------|
+| Cloud Run サービス | run-coachアプリのデプロイ先 |
+| Cloud Scheduler ジョブ | 週次プラン生成トリガー |
+| Secret Manager シークレット | Garmin / OpenAI / DATABASE_URL |
+| GCS バケット | Garminトークン保存 |
+| IAM | サービスアカウント、権限設定 |
+| Workload Identity | Google Calendar認証 |
+
+## やること
+
+- [ ] プライベートリポジトリ `run-coach-infra` 作成
+- [ ] Terraform state の管理方針を決める（GCSバックエンド）
+- [ ] 既存の手動構築リソースをTerraform importする
+- [ ] 各リソースのモジュール化
+- [ ] `terraform plan` / `terraform apply` で再現できることを確認
+
+## 対象外
+
+- CI/CD パイプライン（GitHub Actions からの `terraform apply`）は将来検討


### PR DESCRIPTION
## Summary
- Phase 6（Cloud Run）を段階的に進められるよう4つのサブフェーズに分割
  - 6.1: Dockerfile + ローカルDocker実行
  - 6.2: Cloud Run デプロイ + Secret Manager（Workload Identity / GCSトークン保存）
  - 6.3: Cloud Scheduler + 自動実行
  - 6.4: Terraform インフラ管理（別リポジトリ）
- プロジェクトルールに `.env` 不使用 / `settings.yaml` 管理を追加
- `settings.example.yaml` に `app_port` を追加

## Test plan
- [ ] ドキュメントの内容確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)