### PR TITLE
fix: Cloud Run deploy フラグ修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           gcloud run deploy run-coach \
             --source . \
             --region asia-northeast1 \
-            --allow-unauthenticated=false \
+            --no-allow-unauthenticated \
             --service-account=run-coach-runner@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --set-secrets="GARMIN_EMAIL=GARMIN_EMAIL:latest,GARMIN_PASSWORD=GARMIN_PASSWORD:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest,DATABASE_URL=DATABASE_URL:latest" \
             --set-env-vars="RUN_COACH_GCS_BUCKET=${{ vars.RUN_COACH_GCS_BUCKET }}" \


### PR DESCRIPTION
## Summary
- `--allow-unauthenticated=false` は gcloud で無効な書式
- `--no-allow-unauthenticated` に修正

## Test plan
- [ ] CDのdeployジョブがエラーなく完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)