### PR TITLE
fix: CI/CDワークフロー分割（ci.yml / cd.yml）

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,19 +20,19 @@ jobs:
       postgres:
         image: postgres:17
         env:
-          POSTGRES_DB: ${{ secrets.TEST_POSTGRES_DB }}
-          POSTGRES_USER: ${{ secrets.TEST_POSTGRES_USER }}
+          POSTGRES_DB: run_coach_test
+          POSTGRES_USER: postgres
           POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U ${{ secrets.TEST_POSTGRES_USER }}"
+          --health-cmd "pg_isready -U postgres"
           --health-interval 5s
           --health-timeout 3s
           --health-retries 5
 
     env:
-      DATABASE_URL: postgresql+psycopg://${{ secrets.TEST_POSTGRES_USER }}:${{ secrets.TEST_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.TEST_POSTGRES_DB }}
+      DATABASE_URL: postgresql+psycopg://postgres:${{ secrets.TEST_POSTGRES_PASSWORD }}@localhost:5432/run_coach_test
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,19 @@ jobs:
       postgres:
         image: postgres:17
         env:
-          POSTGRES_DB: ${{ secrets.TEST_POSTGRES_DB }}
-          POSTGRES_USER: ${{ secrets.TEST_POSTGRES_USER }}
+          POSTGRES_DB: run_coach_test
+          POSTGRES_USER: postgres
           POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U ${{ secrets.TEST_POSTGRES_USER }}"
+          --health-cmd "pg_isready -U postgres"
           --health-interval 5s
           --health-timeout 3s
           --health-retries 5
 
     env:
-      DATABASE_URL: postgresql+psycopg://${{ secrets.TEST_POSTGRES_USER }}:${{ secrets.TEST_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.TEST_POSTGRES_DB }}
+      DATABASE_URL: postgresql+psycopg://postgres:${{ secrets.TEST_POSTGRES_PASSWORD }}@localhost:5432/run_coach_test
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- `ci.yml`: PR用（test, gitleaks）— `pull_request`トリガーのみ
- `cd.yml`: デプロイ用（test → deploy）— `push to main` + pathsフィルター（アプリ関連ファイル変更時のみ発火）

## Test plan
- [ ] ブランチでPR作成 → ci.ymlのみ発火確認
- [ ] mainマージ → cd.ymlのみ発火確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)