### PR TITLE
fix: Cloud Run起動時のログ出力とカレンダーID環境変数を追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -107,6 +107,6 @@ jobs:
             --no-allow-unauthenticated \
             --service-account=run-coach-runner@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --set-secrets="GARMIN_EMAIL=GARMIN_EMAIL:latest,GARMIN_PASSWORD=GARMIN_PASSWORD:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest,DATABASE_URL=DATABASE_URL:latest" \
-            --set-env-vars="RUN_COACH_GCS_BUCKET=${{ vars.RUN_COACH_GCS_BUCKET }}" \
+            --set-env-vars="RUN_COACH_GCS_BUCKET=${{ vars.RUN_COACH_GCS_BUCKET }},GOOGLE_CALENDAR_ID=${{ vars.GOOGLE_CALENDAR_ID }}" \
             --memory=512Mi \
             --timeout=300

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY alembic.ini ./
 COPY config/settings.yaml config/settings.yaml
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
-ENV PATH="/app/.venv/bin:$PATH"
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1
 EXPOSE 8080
 CMD ["./entrypoint.sh"]


### PR DESCRIPTION
## Summary
- DockerfileにPYTHONUNBUFFERED=1を追加し、起動エラーログがCloud Runで確認可能にする
- cd.ymlの`--set-env-vars`にGOOGLE_CALENDAR_IDを追加（GitHub Actions Variablesから取得）

## Test plan
- [ ] `gh variable set GOOGLE_CALENDAR_ID` でGitHub Actions Variablesに値を設定
- [ ] PRマージ後、Cloud Runにデプロイされることを確認
- [ ] 起動失敗時にCloud Loggingでエラーログが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)