### PR TITLE
feat: CD にLINE通知用シークレットを追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,7 +106,13 @@ jobs:
             --region=${{ env.REGION }} \
             --no-allow-unauthenticated \
             --service-account=run-coach-runner@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
-            --set-secrets="GARMIN_EMAIL=GARMIN_EMAIL:latest,GARMIN_PASSWORD=GARMIN_PASSWORD:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest,DATABASE_URL=DATABASE_URL:latest" \
+            --set-secrets="\
+              GARMIN_EMAIL=GARMIN_EMAIL:latest,\
+              GARMIN_PASSWORD=GARMIN_PASSWORD:latest,\
+              OPENAI_API_KEY=OPENAI_API_KEY:latest,\
+              DATABASE_URL=DATABASE_URL:latest,\
+              RUN_COACH_LINE_CHANNEL_ACCESS_TOKEN=RUN_COACH_LINE_CHANNEL_ACCESS_TOKEN:latest,\
+              RUN_COACH_LINE_USER_ID=RUN_COACH_LINE_USER_ID:latest" \
             --set-env-vars="RUN_COACH_GCS_BUCKET=${{ vars.RUN_COACH_GCS_BUCKET }},GOOGLE_CALENDAR_ID=${{ vars.GOOGLE_CALENDAR_ID }}" \
             --memory=512Mi \
             --timeout=300


### PR DESCRIPTION
## Summary
- Cloud Run デプロイ時に `RUN_COACH_LINE_CHANNEL_ACCESS_TOKEN` / `RUN_COACH_LINE_USER_ID` を Secret Manager からマウント
- `--set-secrets` の長い行を改行で整形

## Test plan
- [ ] CDパイプラインでデプロイ成功
- [ ] `make scheduler-run` でLINE通知到着

🤖 Generated with [Claude Code](https://claude.com/claude-code)