### PR TITLE
feat: 計画期間を今日起算7日間に変更し、ワークアウト種別を日本語表示

### DIFF
--- a/run_coach/formatter.py
+++ b/run_coach/formatter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from run_coach.calendar import WORKOUT_TYPE_LABEL
 from run_coach.state import AgentState, Plan
 
 INTENSITY_LABEL = {
@@ -35,8 +36,11 @@ def plan_to_markdown(plan: Plan) -> str:
         duration = workout.duration_min or 0
         notes = workout.notes or ""
         day_name = DAY_OF_WEEK[workout.date.weekday()]
+        workout_label = WORKOUT_TYPE_LABEL.get(
+            workout.workout_type, workout.workout_type
+        )
         lines.append(
-            f"| {workout.date} | {day_name} | {workout.workout_type} | {purpose} | {duration} | {intensity} | {hr} | {notes} |"
+            f"| {workout.date} | {day_name} | {workout_label} | {purpose} | {duration} | {intensity} | {hr} | {notes} |"
         )
 
     lines.extend(

--- a/run_coach/line.py
+++ b/run_coach/line.py
@@ -12,6 +12,7 @@ from linebot.v3.messaging import (
     TextMessage,
 )
 
+from run_coach.calendar import WORKOUT_TYPE_LABEL
 from run_coach.formatter import DAY_OF_WEEK
 from run_coach.state import AgentState, Plan
 
@@ -45,8 +46,11 @@ def format_plan_for_line(plan: Plan) -> str:
         day_name = DAY_OF_WEEK[workout.date.weekday()]
         duration = f" {workout.duration_min}min" if workout.duration_min else ""
 
+        workout_label = WORKOUT_TYPE_LABEL.get(
+            workout.workout_type, workout.workout_type
+        )
         lines = [f"{workout.date.month}/{workout.date.day}({day_name})"]
-        lines.append(f"{workout.workout_type}{duration}")
+        lines.append(f"{workout_label}{duration}")
         if workout.max_hr:
             lines.append(f"HR上限{workout.max_hr}")
         if workout.notes:

--- a/run_coach/prompt.py
+++ b/run_coach/prompt.py
@@ -179,14 +179,14 @@ def _build_plan_period_section(profile: UserProfile, signals: Signals) -> list[s
     """計画期間セクションを構築する。"""
     today = date.today()
     today_has_workout = any(w.date == today for w in signals.recent_workouts)
-    plan_start = today + timedelta(days=1) if today_has_workout else today
-    days_until_sunday = (6 - plan_start.weekday()) % 7 or 7
-    plan_end = plan_start + timedelta(days=days_until_sunday)
+    plan_end = today + timedelta(days=6)
 
     parts = [f"\n今日の日付: {today}"]
     if today_has_workout:
-        parts.append("※ 今日は既にワークアウト済みです。")
-    parts.append(f"計画期間: {plan_start} 〜 {plan_end}")
+        parts.append(
+            "※ 今日は既にワークアウト済みのため、今日の追加ワークアウトは不要です。"
+        )
+    parts.append(f"計画期間: {today} 〜 {plan_end}")
     parts.append(
         f"週間走行回数の目安: {profile.runs_per_week.min}〜{profile.runs_per_week.max}回"
     )


### PR DESCRIPTION
## Summary
- 計画期間を「次の日曜まで」から「今日〜6日後」の固定7日間に変更
- 今日ワークアウト済みの場合は追加不要のメッセージを表示
- LINE通知・Markdown出力でworkout_typeをカタカナ表示に統一（WORKOUT_TYPE_LABELを共有）

## Test plan
- [ ] `make local-coach` で計画期間が今日〜6日後になることを確認
- [ ] LINE通知でワークアウト種別がカタカナ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)