### PR TITLE
feat: 振り返りデータをGarmin description に書き戻し

### DIFF
--- a/run_coach/garmin.py
+++ b/run_coach/garmin.py
@@ -183,6 +183,16 @@ def fetch_activity_splits(activity_id: str) -> list[dict]:
         return []
 
 
+def write_description_to_garmin(garmin_activity_id: str, description: str) -> None:
+    """Garmin アクティビティの description を更新する。"""
+    client = _login()
+    client.garth.connectapi(
+        f"/activity-service/activity/{garmin_activity_id}",
+        method="PUT",
+        json={"activityId": garmin_activity_id, "description": description},
+    )
+
+
 def fetch_workouts(state: AgentState) -> AgentState:
     """Fetch recent workouts from Garmin Connect and populate state.signals."""
     print("Garmin Connect からデータを取得中...")

--- a/run_coach/look_back.py
+++ b/run_coach/look_back.py
@@ -13,7 +13,7 @@ from run_coach.database import (
     update_workout_look_back,
     upsert_workouts,
 )
-from run_coach.garmin import _login, summarize_activity
+from run_coach.garmin import _login, summarize_activity, write_description_to_garmin
 from run_coach.line import (
     parse_look_back_message,
     send_look_back_prompt,
@@ -87,23 +87,51 @@ def check_and_prompt_new_activity() -> int:
     return 1
 
 
+def _build_look_back_description(feedback: dict) -> str:
+    """振り返りを Garmin description 用テキストに変換する。"""
+    parts = []
+    if feedback.get("rpe") is not None:
+        parts.append(f"RPE: {feedback['rpe']}")
+    if feedback.get("pain"):
+        parts.append(f"痛み: {feedback['pain']}")
+    if feedback.get("comment"):
+        parts.append(f"コメント: {feedback['comment']}")
+    return "\n".join(parts)
+
+
+def _try_write_back_to_garmin(workout: dict, feedback: dict) -> None:
+    """Garmin description への書き戻しを試みる。失敗してもログのみ。"""
+    if not workout.get("garmin_activity_id") or workout.get("description"):
+        return
+    try:
+        write_description_to_garmin(
+            workout["garmin_activity_id"],
+            _build_look_back_description(feedback),
+        )
+    except Exception:
+        logger.exception("Garmin description write-back failed.")
+
+
 def handle_look_back_reply(text: str, reply_token: str) -> None:
-    """ユーザーの振り返りメッセージを処理してDB保存・LINE返信する。"""
+    """ユーザーの振り返りメッセージを処理してDB保存・Garminへの下記戻し・LINE返信する。"""
     feedback = parse_look_back_message(text)
 
     engine = get_engine()
     with engine.connect() as conn:
         workout = get_pending_look_back_workout(conn)
-        if workout:
-            update_workout_look_back(
-                conn,
-                workout["id"],
-                rpe=feedback["rpe"],
-                pain=feedback["pain"],
-                comment=feedback["comment"],
-            )
-            conn.commit()
-            send_reply(reply_token, "記録しました ✅")
-            logger.info("Look back saved for workout %d.", workout["id"])
-        else:
+        if not workout:
             send_reply(reply_token, "紐付けるワークアウトが見つかりませんでした。")
+            return
+
+        update_workout_look_back(
+            conn,
+            workout["id"],
+            rpe=feedback["rpe"],
+            pain=feedback["pain"],
+            comment=feedback["comment"],
+        )
+        conn.commit()
+
+    _try_write_back_to_garmin(workout, feedback)
+    send_reply(reply_token, "記録しました ✅")
+    logger.info("Look back saved for workout %d.", workout["id"])

--- a/tests/test_look_back.py
+++ b/tests/test_look_back.py
@@ -1,0 +1,177 @@
+"""振り返りロジック + Garmin書き戻しのテスト。"""
+
+from unittest.mock import MagicMock, patch
+
+from run_coach.look_back import _build_look_back_description
+
+
+# --- _build_look_back_description ---
+
+
+def test_build_look_back_description_all_fields():
+    """全フィールド指定時の description テキスト。"""
+    feedback = {"rpe": 7, "pain": "右ひざ", "comment": "調子良かった"}
+    result = _build_look_back_description(feedback)
+    assert result == "RPE: 7\n痛み: 右ひざ\nコメント: 調子良かった"
+
+
+def test_build_look_back_description_rpe_only():
+    """RPEのみの場合。"""
+    feedback = {"rpe": 5, "pain": None, "comment": None}
+    result = _build_look_back_description(feedback)
+    assert result == "RPE: 5"
+
+
+def test_build_look_back_description_comment_only():
+    """コメントのみの場合。"""
+    feedback = {"rpe": None, "pain": None, "comment": "気持ちよく走れた"}
+    result = _build_look_back_description(feedback)
+    assert result == "コメント: 気持ちよく走れた"
+
+
+def test_build_look_back_description_empty():
+    """全フィールド空の場合は空文字列。"""
+    feedback = {"rpe": None, "pain": None, "comment": None}
+    result = _build_look_back_description(feedback)
+    assert result == ""
+
+
+# --- write_description_to_garmin ---
+
+
+def test_write_description_to_garmin():
+    """garth.connectapi が正しいエンドポイント・ペイロードで呼ばれること。"""
+    mock_garth = MagicMock()
+    mock_client = MagicMock()
+    mock_client.garth = mock_garth
+
+    with patch("run_coach.garmin._login", return_value=mock_client):
+        from run_coach.garmin import write_description_to_garmin
+
+        write_description_to_garmin("12345", "RPE: 7")
+
+    mock_garth.connectapi.assert_called_once_with(
+        "/activity-service/activity/12345",
+        method="PUT",
+        json={"activityId": "12345", "description": "RPE: 7"},
+    )
+
+
+# --- handle_look_back_reply with Garmin writeback ---
+
+
+def _make_mock_engine():
+    mock_engine = MagicMock()
+    mock_conn = MagicMock()
+    mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_engine, mock_conn
+
+
+def test_handle_look_back_reply_with_garmin_writeback():
+    """DB保存 + Garmin PUT が呼ばれること。"""
+    mock_workout = {
+        "id": 42,
+        "garmin_activity_id": "ACT001",
+        "description": "",
+    }
+    mock_engine, mock_conn = _make_mock_engine()
+
+    with (
+        patch("run_coach.look_back.get_engine", return_value=mock_engine),
+        patch(
+            "run_coach.look_back.get_pending_look_back_workout",
+            return_value=mock_workout,
+        ),
+        patch("run_coach.look_back.update_workout_look_back") as mock_update,
+        patch("run_coach.look_back.send_reply") as mock_reply,
+        patch("run_coach.look_back.write_description_to_garmin") as mock_write_garmin,
+    ):
+        from run_coach.look_back import handle_look_back_reply
+
+        handle_look_back_reply("RPE: 7\nコメント: 快調", "reply-token")
+
+    mock_update.assert_called_once_with(mock_conn, 42, rpe=7, pain=None, comment="快調")
+    mock_write_garmin.assert_called_once_with("ACT001", "RPE: 7\nコメント: 快調")
+    mock_reply.assert_called_once_with("reply-token", "記録しました ✅")
+
+
+def test_handle_look_back_reply_garmin_failure():
+    """Garmin書き戻し失敗時もLINE返信は成功すること。"""
+    mock_workout = {
+        "id": 42,
+        "garmin_activity_id": "ACT001",
+        "description": "",
+    }
+    mock_engine, mock_conn = _make_mock_engine()
+
+    with (
+        patch("run_coach.look_back.get_engine", return_value=mock_engine),
+        patch(
+            "run_coach.look_back.get_pending_look_back_workout",
+            return_value=mock_workout,
+        ),
+        patch("run_coach.look_back.update_workout_look_back"),
+        patch("run_coach.look_back.send_reply") as mock_reply,
+        patch(
+            "run_coach.look_back.write_description_to_garmin",
+            side_effect=Exception("API error"),
+        ),
+    ):
+        from run_coach.look_back import handle_look_back_reply
+
+        handle_look_back_reply("RPE: 5", "reply-token")
+
+    mock_reply.assert_called_once_with("reply-token", "記録しました ✅")
+
+
+def test_handle_look_back_reply_existing_description():
+    """既存 description がある場合に書き戻しスキップされること。"""
+    mock_workout = {
+        "id": 42,
+        "garmin_activity_id": "ACT001",
+        "description": "既にメモあり",
+    }
+    mock_engine, mock_conn = _make_mock_engine()
+
+    with (
+        patch("run_coach.look_back.get_engine", return_value=mock_engine),
+        patch(
+            "run_coach.look_back.get_pending_look_back_workout",
+            return_value=mock_workout,
+        ),
+        patch("run_coach.look_back.update_workout_look_back"),
+        patch("run_coach.look_back.send_reply"),
+        patch("run_coach.look_back.write_description_to_garmin") as mock_write_garmin,
+    ):
+        from run_coach.look_back import handle_look_back_reply
+
+        handle_look_back_reply("RPE: 5", "reply-token")
+
+    mock_write_garmin.assert_not_called()
+
+
+def test_handle_look_back_reply_no_garmin_id():
+    """garmin_activity_id が None の場合スキップ。"""
+    mock_workout = {
+        "id": 42,
+        "garmin_activity_id": None,
+        "description": "",
+    }
+    mock_engine, mock_conn = _make_mock_engine()
+
+    with (
+        patch("run_coach.look_back.get_engine", return_value=mock_engine),
+        patch(
+            "run_coach.look_back.get_pending_look_back_workout",
+            return_value=mock_workout,
+        ),
+        patch("run_coach.look_back.update_workout_look_back"),
+        patch("run_coach.look_back.send_reply"),
+        patch("run_coach.look_back.write_description_to_garmin") as mock_write_garmin,
+    ):
+        from run_coach.look_back import handle_look_back_reply
+
+        handle_look_back_reply("RPE: 5", "reply-token")
+
+    mock_write_garmin.assert_not_called()


### PR DESCRIPTION
## Summary
- LINE Webhookで受け取った振り返り（RPE/痛み/コメント）をGarmin ConnectアクティビティのdescriptionフィールドにPUT書き戻し
- 既存descriptionがある場合はスキップ（Garminアプリで入力済みのメモを上書きしない）
- 書き戻し失敗時はログ警告のみ（DB保存・LINE返信には影響しない）

## 変更ファイル
- `run_coach/garmin.py`: `write_description_to_garmin()` 追加（`garth.connectapi` PUT）
- `run_coach/look_back.py`: `_build_look_back_description()`, `_try_write_back_to_garmin()` 追加、`handle_look_back_reply` を早期リターンにリファクタ
- `tests/test_look_back.py`: 新規9テスト

## Test plan
- [x] `uv run pytest tests/test_look_back.py` — 9テスト全パス
- [x] `uv run pytest tests/` — 全テストパス（既存のcalendar_sync 3件は環境依存で既知）
- [x] `uv run ruff check` — lint クリーン
- [x] `make up && make local-coach` — Docker環境でパイプライン完走
- [x] 実Garmin APIで書き戻し・読み戻し確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)