### PR TITLE
feat: 振り返りチェック用Cloud Schedulerジョブ追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
        local-coach cloud-coach upload-profile \
        gcp-set-project \
        scheduler-create scheduler-delete scheduler-run scheduler-describe \
+       check-activity-run \
        line-test-message
 
 APP_PORT := $(shell grep '^app_port:' config/settings.yaml 2>/dev/null | awk '{print $$2}')
@@ -114,6 +115,13 @@ scheduler-run: ## Cloud Schedulerジョブを手動実行（テスト用）
 
 scheduler-describe: ## Cloud Schedulerジョブの状態を表示
 	gcloud scheduler jobs describe $(SCHEDULER_JOB) --location=$(SCHEDULER_REGION)
+
+# ── Cloud Scheduler (check-new-activity) ──────────
+
+CHECK_ACTIVITY_JOB := run-coach-check-activity
+
+check-activity-run: ## 振り返りチェックジョブを手動実行（テスト用）
+	gcloud scheduler jobs run $(CHECK_ACTIVITY_JOB) --location=$(SCHEDULER_REGION)
 
 # ── LINE ───────────────────────────────────────────
 

--- a/docs/phase7-line.md
+++ b/docs/phase7-line.md
@@ -55,6 +55,28 @@ flowchart LR
 - [ ] Webhook受信 → 振り返りをPostgreSQL保存 + Garmin書き戻し
 - [ ] 環境変数: `LINE_CHANNEL_ACCESS_TOKEN`, `LINE_USER_ID`, `LINE_CHANNEL_SECRET`
 
+## Cloud Scheduler（振り返りチェック）
+
+Cloud Schedulerで `POST /check-new-activity` を定期実行し、新着ランを検知してLINEで振り返りプロンプトを自動送信する。
+
+| 設定 | 値 |
+|------|-----|
+| ジョブ名 | `run-coach-check-activity` |
+| スケジュール | `0 12-23 * * *`（毎日12時〜23時、毎時） |
+| タイムゾーン | `Asia/Tokyo` |
+| ターゲット | Cloud Runの `POST /check-new-activity` |
+| 認証 | OIDC（`run-coach-scheduler` SA） |
+| デッドライン | 60秒 |
+| リトライ | 最大2回、30秒〜120秒バックオフ |
+
+### Makefileコマンド
+
+```bash
+make check-activity-run      # 手動実行（テスト用）
+```
+
+ジョブの作成・削除は `run-coach-infra` リポジトリ（Terraform）で管理する。
+
 ## メッセージ形式（案）
 
 ```


### PR DESCRIPTION
## Summary
- 毎日12〜23時（JST）に毎時 `POST /check-new-activity` を実行するCloud Schedulerジョブ `run-coach-check-activity` を追加
- Makefileに `check-activity-run`（手動実行）ターゲットを追加
- ジョブのライフサイクル管理（create/delete）は `run-coach-infra`（Terraform）で管理

## Test plan
- [x] `gcloud scheduler jobs create` でジョブ作成済み
- [x] 16:00 JST に自動実行され、LINE振り返りプロンプトの送信を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)