### PR TITLE
fix: auth テストがCIでGarminログインを試行する問題を修正

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,7 +10,7 @@ def test_oidc_skip_when_not_cloud_run(_mock_conn):
     """ローカル環境ではOIDC検証をスキップし、エンドポイントにアクセスできる。"""
     with (
         patch("run_coach.auth.is_cloud_run", return_value=False),
-        patch("run_coach.look_back.check_and_prompt_new_activity", return_value=0),
+        patch("run_coach.api.check_and_prompt_new_activity", return_value=0),
     ):
         from run_coach.api import app
 
@@ -20,8 +20,13 @@ def test_oidc_skip_when_not_cloud_run(_mock_conn):
     assert response.status_code == 200
 
 
+@patch("run_coach.api.prefetch_tokens")
+@patch("run_coach.api.ensure_profile")
+@patch("run_coach.api._validate_env")
 @patch("run_coach.api.check_connection")
-def test_oidc_missing_bearer_token(_mock_conn, monkeypatch):
+def test_oidc_missing_bearer_token(
+    _mock_conn, _mock_validate, _mock_profile, _mock_tokens, monkeypatch
+):
     """Cloud RunでAuthorizationヘッダーがない場合は401。"""
     monkeypatch.setenv("K_SERVICE", "run-coach")
     monkeypatch.setenv("RUN_COACH_ALLOWED_SA", "any@project.iam.gserviceaccount.com")
@@ -34,8 +39,13 @@ def test_oidc_missing_bearer_token(_mock_conn, monkeypatch):
     assert response.status_code == 401
 
 
+@patch("run_coach.api.prefetch_tokens")
+@patch("run_coach.api.ensure_profile")
+@patch("run_coach.api._validate_env")
 @patch("run_coach.api.check_connection")
-def test_oidc_invalid_token(_mock_conn, monkeypatch):
+def test_oidc_invalid_token(
+    _mock_conn, _mock_validate, _mock_profile, _mock_tokens, monkeypatch
+):
     """Cloud Runで不正なトークンの場合は401。"""
     monkeypatch.setenv("K_SERVICE", "run-coach")
     monkeypatch.setenv("RUN_COACH_ALLOWED_SA", "any@project.iam.gserviceaccount.com")
@@ -52,8 +62,13 @@ def test_oidc_invalid_token(_mock_conn, monkeypatch):
     assert response.status_code == 401
 
 
+@patch("run_coach.api.prefetch_tokens")
+@patch("run_coach.api.ensure_profile")
+@patch("run_coach.api._validate_env")
 @patch("run_coach.api.check_connection")
-def test_oidc_unauthorized_service_account(_mock_conn, monkeypatch):
+def test_oidc_unauthorized_service_account(
+    _mock_conn, _mock_validate, _mock_profile, _mock_tokens, monkeypatch
+):
     """Cloud Runで許可されていないSAの場合は403。"""
     monkeypatch.setenv("K_SERVICE", "run-coach")
     monkeypatch.setenv(
@@ -74,8 +89,13 @@ def test_oidc_unauthorized_service_account(_mock_conn, monkeypatch):
     assert response.status_code == 403
 
 
+@patch("run_coach.api.prefetch_tokens")
+@patch("run_coach.api.ensure_profile")
+@patch("run_coach.api._validate_env")
 @patch("run_coach.api.check_connection")
-def test_oidc_valid_token(_mock_conn, monkeypatch):
+def test_oidc_valid_token(
+    _mock_conn, _mock_validate, _mock_profile, _mock_tokens, monkeypatch
+):
     """Cloud Runで正しいトークンとSAの場合は通過する。"""
     monkeypatch.setenv("K_SERVICE", "run-coach")
     monkeypatch.setenv(
@@ -86,7 +106,7 @@ def test_oidc_valid_token(_mock_conn, monkeypatch):
 
     with (
         patch("run_coach.auth.id_token.verify_oauth2_token", return_value=claims),
-        patch("run_coach.look_back.check_and_prompt_new_activity", return_value=0),
+        patch("run_coach.api.check_and_prompt_new_activity", return_value=0),
     ):
         from run_coach.api import app
 
@@ -100,8 +120,13 @@ def test_oidc_valid_token(_mock_conn, monkeypatch):
     assert response.json() == {"prompted": 0}
 
 
+@patch("run_coach.api.prefetch_tokens")
+@patch("run_coach.api.ensure_profile")
+@patch("run_coach.api._validate_env")
 @patch("run_coach.api.check_connection")
-def test_oidc_multiple_allowed_sa(_mock_conn, monkeypatch):
+def test_oidc_multiple_allowed_sa(
+    _mock_conn, _mock_validate, _mock_profile, _mock_tokens, monkeypatch
+):
     """複数の許可SA指定でマッチする場合は通過する。"""
     monkeypatch.setenv("K_SERVICE", "run-coach")
     monkeypatch.setenv(
@@ -113,7 +138,7 @@ def test_oidc_multiple_allowed_sa(_mock_conn, monkeypatch):
 
     with (
         patch("run_coach.auth.id_token.verify_oauth2_token", return_value=claims),
-        patch("run_coach.look_back.check_and_prompt_new_activity", return_value=0),
+        patch("run_coach.api.check_and_prompt_new_activity", return_value=0),
     ):
         from run_coach.api import app
 
@@ -124,6 +149,20 @@ def test_oidc_multiple_allowed_sa(_mock_conn, monkeypatch):
         )
 
     assert response.status_code == 200
+
+
+def test_startup_fails_without_required_env(monkeypatch):
+    """Cloud Runで必須環境変数が未設定だと起動時にエラー。"""
+    monkeypatch.setenv("K_SERVICE", "run-coach")
+    monkeypatch.delenv("RUN_COACH_ALLOWED_SA", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    import pytest
+
+    from run_coach.api import _validate_env
+
+    with pytest.raises(RuntimeError, match="Missing required env vars"):
+        _validate_env()
 
 
 @patch("run_coach.api.check_connection")


### PR DESCRIPTION
## Summary
- K_SERVICE設定時にlifespanの `prefetch_tokens`/`ensure_profile`/`_validate_env` をモックし、CIでGarminログインが走らないように修正
- `check_and_prompt_new_activity` のモック先を `run_coach.look_back` → `run_coach.api` に修正（直接インポートされているため）

## Test plan
- [x] `uv run pytest tests/test_auth.py -v` — 8件パス
- [ ] CI で3件のテスト失敗が解消されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)