### PR TITLE
feat: CDワークフローにworkflow_dispatch追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: CD
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- CDワークフローに `workflow_dispatch` トリガーを追加し、手動実行を可能にする
- マージによりCDが再トリガーされ、PR #46のテスト修正が反映される

## Test plan
- [ ] PRマージ後、CDワークフローが成功すること
- [ ] Actions タブから手動トリガーが可能なこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)