### PR TITLE
docs: Makefile操作用のClaude Codeスキルを追加

### DIFF
--- a/.claude/skills/cloud-verify/SKILL.md
+++ b/.claude/skills/cloud-verify/SKILL.md
@@ -1,0 +1,54 @@
+# クラウド環境動作確認
+
+Cloud Run上のAPIにリクエストを送り、動作確認を行うスキル。
+
+## トリガー
+
+ユーザーが「クラウド確認」「Cloud Run確認」「本番確認」「cloud」を依頼した時。
+
+## コマンド一覧
+
+```bash
+# プラン生成 API（Cloud Run、OIDC認証付き）
+make cloud-coach
+
+# Cloud Schedulerジョブを手動実行
+make scheduler-run
+
+# 振り返りチェックジョブを手動実行
+make check-activity-run
+
+# Cloud Schedulerジョブの状態確認
+make scheduler-describe
+
+# GCPプロジェクト切り替え
+make gcp-set-project
+
+# profile.yaml を GCS にアップロード
+make upload-profile
+```
+
+## 手順
+
+### API動作確認
+
+1. `make gcp-set-project` でプロジェクトが正しいか確認
+2. `make cloud-coach` でCloud RunのAPIを叩く
+3. レスポンスのJSONを確認
+
+### Cloud Scheduler動作確認
+
+1. `make scheduler-describe` でジョブの状態を確認
+2. `make scheduler-run` で手動実行
+3. Cloud Runのログで実行結果を確認
+
+### 設定ファイル更新
+
+1. `config/profile.yaml` を編集
+2. `make upload-profile` でGCSにアップロード
+
+## 注意
+
+- `gcloud auth login` 済みであること
+- `cloud-coach` は gcloud でIDトークンを取得しOIDC認証ヘッダを付与する
+- 環境変数 `RUN_COACH_GCP_PROJECT_ID`, `RUN_COACH_GCS_BUCKET` が必要なコマンドあり

--- a/.claude/skills/container-ops/SKILL.md
+++ b/.claude/skills/container-ops/SKILL.md
@@ -1,0 +1,52 @@
+# ローカルコンテナ操作
+
+Docker Composeでapp + dbの起動・停止・ログ確認を行うスキル。
+
+## トリガー
+
+ユーザーが「コンテナ」「docker」「起動」「停止」「ログ」を依頼した時。
+
+## コマンド一覧
+
+```bash
+# app + db 起動
+make up
+
+# 停止
+make down
+
+# ログ表示（follow）
+make logs
+
+# コンテナ状態を確認
+make ps
+
+# app を再起動
+make restart
+
+# app イメージをリビルド
+make build
+
+# DB のみ起動
+make db-up
+
+# DB のみ停止
+make db-down
+
+# DB ログ表示
+make db-logs
+
+# psql で接続
+make db-psql
+```
+
+## 手順
+
+1. `make ps` でコンテナの現在の状態を確認
+2. 目的に応じたコマンドを実行
+3. 実行後に `make ps` で状態を再確認
+
+## 注意
+
+- `make up` は `--build` 付きなのでコード変更が自動反映される
+- ポート番号は `config/settings.yaml` の `app_port` から取得される（デフォルト: 8080）

--- a/.claude/skills/local-verify/SKILL.md
+++ b/.claude/skills/local-verify/SKILL.md
@@ -1,0 +1,31 @@
+# ローカル動作確認
+
+ローカルのDockerコンテナに対してAPIリクエストを送り、動作確認を行うスキル。
+
+## トリガー
+
+ユーザーが「ローカル確認」「動作確認」「local」「ローカルで試す」を依頼した時。
+
+## コマンド一覧
+
+```bash
+# プラン生成 API（JSON整形出力）
+make local-coach
+
+# LINE テスト送信
+make line-test-message
+```
+
+## 手順
+
+1. `make ps` でコンテナが起動しているか確認
+2. 起動していなければ `make up` で起動
+3. `make logs` でアプリの起動完了を確認
+4. `make local-coach` でプラン生成APIを叩く
+5. レスポンスのJSONを確認
+
+## 注意
+
+- コンテナが起動していないとリクエストが失敗する
+- `local-coach` は `POST /internal/coach` にリクエストを送る（ローカルではOIDC検証なし）
+- `line-test-message` は `RUN_COACH_LINE_CHANNEL_ACCESS_TOKEN` と `RUN_COACH_LINE_USER_ID` 環境変数が必要

--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -1,0 +1,45 @@
+# マイグレーション
+
+Alembicによるデータベースマイグレーションを管理するスキル。
+
+## トリガー
+
+ユーザーが「マイグレーション」「migrate」「DB変更」「テーブル追加」を依頼した時。
+
+## コマンド一覧
+
+```bash
+# マイグレーション実行（最新まで適用）
+make migrate
+
+# マイグレーション履歴を表示
+make migrate-history
+
+# 新規マイグレーション作成（モデル変更後に実行）
+make migrate-new MSG="add users table"
+
+# 1つ前にロールバック
+make migrate-down
+```
+
+## 手順
+
+### 新規マイグレーション作成
+
+1. SQLAlchemyモデルを変更
+2. DBコンテナが起動していることを確認（`make db-up`）
+3. `make migrate-new MSG="変更の説明"` で自動生成
+4. 生成されたファイル（`alembic/versions/`）を確認・修正
+5. `make migrate` で適用
+6. `make migrate-history` で反映を確認
+
+### ロールバック
+
+1. `make migrate-history` で現在の状態を確認
+2. `make migrate-down` で1つ戻す
+3. 必要に応じて繰り返す
+
+## 注意
+
+- マイグレーション実行前にDBコンテナが起動している必要がある
+- autogenerateの結果は必ず目視確認すること（意図しない変更が含まれる場合がある）


### PR DESCRIPTION
## Summary
- コンテナ操作（container-ops）、マイグレーション（migration）、ローカル動作確認（local-verify）、クラウド動作確認（cloud-verify）の4スキルを追加
- Makefileのコマンドをスキル経由で呼び出せるようになる

## Test plan
- [ ] `/container-ops` `/migration` `/local-verify` `/cloud-verify` がスキル一覧に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)