### PR TITLE
fix: Garmin API 429リトライ対応（exponential backoff）

### DIFF
--- a/run_coach/garmin.py
+++ b/run_coach/garmin.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from datetime import date, timedelta
 from pathlib import Path
 
-from garminconnect import Garmin, GarminConnectAuthenticationError  # type: ignore[import-untyped]
+from garminconnect import (
+    Garmin,
+    GarminConnectAuthenticationError,
+    GarminConnectTooManyRequestsError,
+)  # type: ignore[import-untyped]
 
 from run_coach.cloud import is_cloud_run
 from run_coach.converters import pace_seconds_to_str
@@ -17,12 +22,18 @@ logger = logging.getLogger(__name__)
 GARMIN_TOKENSTORE_LOCAL = str(Path.home() / ".garminconnect")
 GARMIN_TOKENSTORE_CLOUD = "/tmp/.garminconnect"
 GCS_GARMIN_TOKEN_PREFIX = "garmin-tokens"
+
 # 一度に取得するアクティビティの最大件数
 ACTIVITY_FETCH_LIMIT = 10
 # ワークアウト履歴の取得対象期間（日数）
 LOOKBACK_DAYS = 14
 # 大会情報のスキャン対象期間（月数）
 RACE_SCAN_MONTHS = 12
+
+# ログイン429リトライ設定
+LOGIN_MAX_RETRIES = 3
+LOGIN_INITIAL_BACKOFF_SECONDS = 10
+
 # 取得対象のアクティビティタイプ
 TARGET_ACTIVITY_TYPES = (
     "running",
@@ -80,11 +91,28 @@ def _login() -> Garmin:
     email = os.environ.get("GARMIN_EMAIL", "")
     password = os.environ.get("GARMIN_PASSWORD", "")
     client = Garmin(email=email, password=password)
-    try:
-        client.login(tokenstore=tokenstore)
-    except (FileNotFoundError, GarminConnectAuthenticationError):
-        logger.info("トークンが無効または未保存のため、クレデンシャルでログインします")
-        client.login()
+
+    for attempt in range(LOGIN_MAX_RETRIES + 1):
+        try:
+            client.login(tokenstore=tokenstore)
+            break
+        except (FileNotFoundError, GarminConnectAuthenticationError):
+            logger.info(
+                "トークンが無効または未保存のため、クレデンシャルでログインします"
+            )
+            client.login()
+            break
+        except GarminConnectTooManyRequestsError:
+            if attempt == LOGIN_MAX_RETRIES:
+                raise
+            wait = LOGIN_INITIAL_BACKOFF_SECONDS * (2**attempt)
+            logger.warning(
+                "Garmin API レート制限 (429)。%d秒後にリトライします (%d/%d)",
+                wait,
+                attempt + 1,
+                LOGIN_MAX_RETRIES,
+            )
+            time.sleep(wait)
 
     # リフレッシュ済みトークンを含め毎回保存（次回セッションで再利用）
     client.garth.dump(tokenstore)

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1,4 +1,8 @@
-from run_coach.garmin import parse_splits, summarize_activity
+from unittest.mock import MagicMock, patch
+
+from garminconnect import GarminConnectTooManyRequestsError  # type: ignore[import-untyped]
+
+from run_coach.garmin import LOGIN_MAX_RETRIES, parse_splits, summarize_activity
 
 
 def _make_activity(**overrides) -> dict:
@@ -100,6 +104,61 @@ def test_parse_splits_empty():
     """空のレスポンスでも動くこと"""
     assert parse_splits({}) == []
     assert parse_splits({"lapDTOs": []}) == []
+
+
+def _reset_garmin_client():
+    """テスト前にキャッシュされたGarminクライアントをリセットする。"""
+    import run_coach.garmin as garmin_mod
+
+    garmin_mod._garmin_client = None
+
+
+@patch("run_coach.garmin.time.sleep")
+@patch("run_coach.garmin.Garmin")
+def test_login_retries_on_429_then_succeeds(mock_garmin_cls, mock_sleep, monkeypatch):
+    """429が返っても exponential backoff でリトライし、最終的にログイン成功すること"""
+    _reset_garmin_client()
+    monkeypatch.setenv("GARMIN_EMAIL", "test@example.com")
+    monkeypatch.setenv("GARMIN_PASSWORD", "pass")
+
+    mock_client = MagicMock()
+    mock_garmin_cls.return_value = mock_client
+    mock_client.login.side_effect = [
+        GarminConnectTooManyRequestsError("429"),
+        None,  # 2回目で成功
+    ]
+
+    from run_coach.garmin import _login
+
+    client = _login()
+
+    assert client is mock_client
+    assert mock_client.login.call_count == 2
+    mock_sleep.assert_called_once_with(10)  # LOGIN_INITIAL_BACKOFF_SECONDS * 2^0
+    _reset_garmin_client()
+
+
+@patch("run_coach.garmin.time.sleep")
+@patch("run_coach.garmin.Garmin")
+def test_login_raises_after_max_retries(mock_garmin_cls, mock_sleep, monkeypatch):
+    """最大リトライ回数を超えたら GarminConnectTooManyRequestsError が re-raise されること"""
+    _reset_garmin_client()
+    monkeypatch.setenv("GARMIN_EMAIL", "test@example.com")
+    monkeypatch.setenv("GARMIN_PASSWORD", "pass")
+
+    mock_client = MagicMock()
+    mock_garmin_cls.return_value = mock_client
+    mock_client.login.side_effect = GarminConnectTooManyRequestsError("429")
+
+    import pytest
+    from run_coach.garmin import _login
+
+    with pytest.raises(GarminConnectTooManyRequestsError):
+        _login()
+
+    assert mock_client.login.call_count == LOGIN_MAX_RETRIES + 1
+    assert mock_sleep.call_count == LOGIN_MAX_RETRIES
+    _reset_garmin_client()
 
 
 def test_parse_splits_missing_hr():


### PR DESCRIPTION
## Summary

- `_login()` に `GarminConnectTooManyRequestsError` のキャッチと exponential backoff リトライ（10s→20s→40s、最大3回）を追加
- Cloud Schedulerの短間隔リトライで429を繰り返す悪循環を防止
- テスト2件追加（リトライ成功・最大リトライ超過時のre-raise）

## Test plan

- [x] `uv run pytest tests/test_garmin.py` — 9件全通過
- [x] `uv run ruff check run_coach/ tests/` — lint通過
- [x] `make up` でコンテナビルド・起動確認
- [ ] `make scheduler-run` で Cloud Run 上の動作確認（任意）

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)