### PR TITLE
fix: Google Calendar RefreshErrorハンドリング (#56)

### DIFF
--- a/run_coach/calendar.py
+++ b/run_coach/calendar.py
@@ -5,6 +5,7 @@ import os
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
+from google.auth.exceptions import RefreshError  # type: ignore[import-untyped]
 from google.auth.transport.requests import Request  # type: ignore[import-untyped]
 from google.oauth2.credentials import Credentials  # type: ignore[import-untyped]
 from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import-untyped]
@@ -35,19 +36,23 @@ def _get_calendar_service() -> Resource:
         creds, _ = google.auth.default(scopes=SCOPES)
         return build("calendar", "v3", credentials=creds)
 
-    creds = None
+    creds = None  # type: ignore[assignment]
     if TOKEN_PATH.exists():
         creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
 
     if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
+        if creds and creds.expired and getattr(creds, "refresh_token", None):
+            try:
+                creds.refresh(Request())
+            except RefreshError:
+                logger.warning("リフレッシュトークンが失効しました。再認証を試みます")
+                creds = None  # type: ignore[assignment]  # re-widen to trigger re-auth
+        if not creds:
             flow = InstalledAppFlow.from_client_secrets_file(
                 str(CLIENT_SECRET_PATH), SCOPES
             )
-            creds = flow.run_local_server(port=0)
-        TOKEN_PATH.write_text(creds.to_json())
+            creds = flow.run_local_server(port=0)  # type: ignore[assignment]
+        TOKEN_PATH.write_text(creds.to_json())  # type: ignore[union-attr]
 
     return build("calendar", "v3", credentials=creds)
 
@@ -116,7 +121,7 @@ def fetch_calendar(state: AgentState) -> AgentState:
         service = _get_calendar_service()
         events_by_date = _fetch_events(service)
         state.constraints.available_slots = _build_slots(events_by_date)
-    except (HttpError, OSError, ValueError):
+    except (HttpError, OSError, ValueError, RefreshError):
         logger.warning("カレンダーの取得に失敗しました", exc_info=True)
 
     print(f"  {len(state.constraints.available_slots)} 日分のスロットを取得しました")
@@ -235,7 +240,7 @@ def sync_plan_to_calendar(state: AgentState) -> AgentState:
             _create_workout_event(service, workout)
 
         print(f"  {len(workouts_to_sync)} 件のワークアウトをカレンダーに登録しました")
-    except (HttpError, OSError, ValueError):
+    except (HttpError, OSError, ValueError, RefreshError):
         logger.warning("カレンダーへの同期に失敗しました", exc_info=True)
 
     return state

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -23,6 +23,8 @@ from run_coach.state import (
     WorkoutPlan,
 )
 
+CALENDAR_ID_PATCH = patch("run_coach.calendar._get_calendar_id", return_value="primary")
+
 
 def _make_state(workouts: list[WorkoutPlan] | None = None) -> AgentState:
     """テスト用のAgentStateを生成する。"""
@@ -146,7 +148,8 @@ class TestBuildEventBody:
 
 
 class TestDeleteRunCoachEvents:
-    def test_deletes_matching_events(self) -> None:
+    @CALENDAR_ID_PATCH
+    def test_deletes_matching_events(self, _mock_cal_id: MagicMock) -> None:
         mock_service = MagicMock()
         mock_events = mock_service.events.return_value
         mock_events.list.return_value.execute.return_value = {
@@ -177,7 +180,8 @@ class TestDeleteRunCoachEvents:
         assert deleted == 0
         mock_events.delete.assert_not_called()
 
-    def test_uses_extended_property_filter(self) -> None:
+    @CALENDAR_ID_PATCH
+    def test_uses_extended_property_filter(self, _mock_cal_id: MagicMock) -> None:
         mock_service = MagicMock()
         mock_events = mock_service.events.return_value
         mock_events.list.return_value.execute.return_value = {"items": []}
@@ -237,12 +241,14 @@ class TestSyncPlanToCalendar:
 
         assert result.plan is not None
 
+    @CALENDAR_ID_PATCH
     @patch("run_coach.calendar._get_calendar_service")
     @patch("run_coach.calendar.CLIENT_SECRET_PATH")
     def test_deletes_before_insert(
         self,
         mock_path: MagicMock,
         mock_get_service: MagicMock,
+        _mock_cal_id: MagicMock,
         sample_workouts: list[WorkoutPlan],
     ) -> None:
         mock_path.exists.return_value = True

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -5,11 +5,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from google.auth.exceptions import RefreshError
+
 from run_coach.calendar import (
     EXTENDED_PROPERTY_KEY,
     EXTENDED_PROPERTY_VALUE,
     _build_event_body,
     _delete_run_coach_events,
+    fetch_calendar,
     sync_plan_to_calendar,
 )
 from run_coach.state import (
@@ -273,3 +276,72 @@ class TestSyncPlanToCalendar:
 
         mock_get_service.assert_not_called()
         assert result.plan is not None
+
+
+@patch(
+    "run_coach.calendar._get_calendar_service",
+    side_effect=RefreshError("token revoked"),
+)
+@patch("run_coach.calendar.CLIENT_SECRET_PATH")
+def test_fetch_calendar_skips_on_refresh_error(
+    mock_path: MagicMock, mock_get_service: MagicMock
+) -> None:
+    """RefreshError発生時にfetch_calendarがクラッシュせずstateを返すこと。"""
+    mock_path.exists.return_value = True
+    state = _make_state()
+    result = fetch_calendar(state)
+
+    assert result.constraints.available_slots == []
+
+
+@patch(
+    "run_coach.calendar._get_calendar_service",
+    side_effect=RefreshError("token revoked"),
+)
+@patch("run_coach.calendar.CLIENT_SECRET_PATH")
+def test_sync_skips_on_refresh_error(
+    mock_path: MagicMock,
+    mock_get_service: MagicMock,
+    sample_workouts: list[WorkoutPlan],
+) -> None:
+    """RefreshError発生時にsync_plan_to_calendarがクラッシュせずstateを返すこと。"""
+    mock_path.exists.return_value = True
+    state = _make_state(sample_workouts)
+    result = sync_plan_to_calendar(state)
+
+    assert result.plan is not None
+
+
+@patch("run_coach.calendar.build")
+@patch("run_coach.calendar.InstalledAppFlow")
+@patch("run_coach.calendar.TOKEN_PATH")
+@patch("run_coach.calendar.is_cloud_run", return_value=False)
+def test_get_calendar_service_refresh_error_retries_auth(
+    mock_is_cloud: MagicMock,
+    mock_token_path: MagicMock,
+    mock_flow_cls: MagicMock,
+    mock_build: MagicMock,
+) -> None:
+    """creds.refresh()でRefreshError時にInstalledAppFlowで再認証すること。"""
+    mock_creds = MagicMock()
+    mock_creds.valid = False
+    mock_creds.expired = True
+    mock_creds.refresh_token = "old_token"
+    mock_creds.refresh.side_effect = RefreshError("token revoked")
+    mock_token_path.exists.return_value = True
+
+    mock_new_creds = MagicMock()
+    mock_flow = MagicMock()
+    mock_flow.run_local_server.return_value = mock_new_creds
+    mock_flow_cls.from_client_secrets_file.return_value = mock_flow
+
+    with patch(
+        "run_coach.calendar.Credentials.from_authorized_user_file",
+        return_value=mock_creds,
+    ):
+        from run_coach.calendar import _get_calendar_service
+
+        _get_calendar_service()
+
+    mock_flow.run_local_server.assert_called_once()
+    mock_build.assert_called_once_with("calendar", "v3", credentials=mock_new_creds)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -126,6 +126,7 @@ def test_graph_full_flow(monkeypatch):
     monkeypatch.setattr("run_coach.graph.fetch_weather", noop)
     monkeypatch.setattr("run_coach.planner.generate_plan", mock_generate_plan)
     monkeypatch.setattr("run_coach.graph.self_check", mock_self_check)
+    monkeypatch.setattr("run_coach.graph.sync_plan_to_calendar", noop)
     monkeypatch.setattr("run_coach.graph.output_plan", noop)
     monkeypatch.setattr("run_coach.graph.notify_line", noop)
 
@@ -168,6 +169,7 @@ def test_graph_retry_flow(monkeypatch):
     monkeypatch.setattr("run_coach.graph.fetch_weather", noop)
     monkeypatch.setattr("run_coach.planner.generate_plan", mock_generate_plan)
     monkeypatch.setattr("run_coach.graph.self_check", mock_self_check)
+    monkeypatch.setattr("run_coach.graph.sync_plan_to_calendar", noop)
     monkeypatch.setattr("run_coach.graph.output_plan", noop)
     monkeypatch.setattr("run_coach.graph.notify_line", noop)
 


### PR DESCRIPTION
## Summary
- `_get_calendar_service()`で`RefreshError`発生時に`InstalledAppFlow`へフォールスルーしてトークン再発行を試行
- `fetch_calendar`/`sync_plan_to_calendar`のexcept句に`RefreshError`を追加（安全策）
- `GOOGLE_CALENDAR_ID`環境変数設定時にテストが失敗する問題を修正

## Test plan
- [x] `uv run pytest tests/` 全132テストパス
- [x] RefreshError発生時にfetch_calendar/sync_plan_to_calendarがクラッシュしないことをテストで確認
- [x] RefreshError時にInstalledAppFlowへフォールスルーすることをテストで確認

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)