### PR TITLE
fix: Garminログイン429リトライのcatch漏れ修正とbackoff増加

### DIFF
--- a/run_coach/garmin.py
+++ b/run_coach/garmin.py
@@ -32,7 +32,7 @@ RACE_SCAN_MONTHS = 12
 
 # ログイン429リトライ設定
 LOGIN_MAX_RETRIES = 3
-LOGIN_INITIAL_BACKOFF_SECONDS = 10
+LOGIN_INITIAL_BACKOFF_SECONDS = 30
 
 # 取得対象のアクティビティタイプ
 TARGET_ACTIVITY_TYPES = (
@@ -94,13 +94,13 @@ def _login() -> Garmin:
 
     for attempt in range(LOGIN_MAX_RETRIES + 1):
         try:
-            client.login(tokenstore=tokenstore)
-            break
-        except (FileNotFoundError, GarminConnectAuthenticationError):
-            logger.info(
-                "トークンが無効または未保存のため、クレデンシャルでログインします"
-            )
-            client.login()
+            try:
+                client.login(tokenstore=tokenstore)
+            except (FileNotFoundError, GarminConnectAuthenticationError):
+                logger.info(
+                    "トークンが無効または未保存のため、クレデンシャルでログインします"
+                )
+                client.login()
             break
         except GarminConnectTooManyRequestsError:
             if attempt == LOGIN_MAX_RETRIES:

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -134,7 +134,7 @@ def test_login_retries_on_429_then_succeeds(mock_garmin_cls, mock_sleep, monkeyp
 
     assert client is mock_client
     assert mock_client.login.call_count == 2
-    mock_sleep.assert_called_once_with(10)  # LOGIN_INITIAL_BACKOFF_SECONDS * 2^0
+    mock_sleep.assert_called_once_with(30)  # LOGIN_INITIAL_BACKOFF_SECONDS * 2^0
     _reset_garmin_client()
 
 


### PR DESCRIPTION
## Summary
- fallback credential login (`client.login()`) で発生した429が `GarminConnectTooManyRequestsError` として捕捉されず、リトライループ外に飛ぶ構造的バグを修正
- 初期backoffを10s→30sに増加（合計待ち時間: 70s→210s）し、Garminレート制限解除を待つ余裕を確保

## 背景
Cloud Run scheduler実行時に `oauth/exchange/user/2.0` で429が発生しログイン失敗。
リトライ自体は動作するが、backoffが短すぎてGarmin側のレート制限が解除されない。

## Test plan
- [x] `uv run pytest tests/` 全テストパス（132 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)