### PR TITLE
fix: Garminトークンローカルアップロードスクリプト追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help up down build logs ps restart \
        db-up db-down db-logs db-psql \
        migrate migrate-history migrate-new migrate-down \
-       local-coach cloud-coach upload-profile \
+       local-coach cloud-coach upload-profile upload-garmin-tokens \
        gcp-set-project \
        scheduler-create scheduler-delete scheduler-run scheduler-describe \
        check-activity-run \
@@ -80,6 +80,9 @@ gcp-set-project: ## GCPプロジェクトを切り替え（要: RUN_COACH_GCP_PR
 	@echo "プロジェクトを $(RUN_COACH_GCP_PROJECT_ID) に切り替えました"
 
 # ── GCS ─────────────────────────────────────────────
+
+upload-garmin-tokens: ## Garminトークンをリフレッシュし GCS にアップロード（要: GARMIN_EMAIL, GARMIN_PASSWORD, RUN_COACH_GCS_BUCKET）
+	uv run python -m scripts.upload_garmin_tokens
 
 upload-profile: ## profile.yaml を GCS にアップロード（要: RUN_COACH_GCS_BUCKET 環境変数）
 	@test -n "$(RUN_COACH_GCS_BUCKET)" || (echo "Error: RUN_COACH_GCS_BUCKET 環境変数が未設定です" && exit 1)

--- a/scripts/upload_garmin_tokens.py
+++ b/scripts/upload_garmin_tokens.py
@@ -1,0 +1,68 @@
+"""ローカルPCでGarminトークンをリフレッシュしGCSにアップロードする。
+
+クラウドIP（AWS/GCP等）からのOAuthトークン交換が429で拒否される問題の暫定対策。
+住宅IPからトークンを更新し、Cloud Runがそれを利用することでexchangeを回避する。
+
+使い方:
+    make upload-garmin-tokens
+
+必要な環境変数:
+    GARMIN_EMAIL, GARMIN_PASSWORD, RUN_COACH_GCS_BUCKET
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from garminconnect import (
+    Garmin,
+    GarminConnectAuthenticationError,
+)  # type: ignore[import-untyped]
+from google.cloud import storage  # type: ignore[import-untyped]
+
+TOKENSTORE = str(Path.home() / ".garminconnect")
+GCS_TOKEN_PREFIX = "garmin-tokens"
+REQUIRED_ENV_VARS = ("GARMIN_EMAIL", "GARMIN_PASSWORD", "RUN_COACH_GCS_BUCKET")
+
+
+def main() -> None:
+    missing = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
+    if missing:
+        print(f"エラー: 環境変数が未設定です: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+
+    bucket = os.environ["RUN_COACH_GCS_BUCKET"]
+
+    client = Garmin(
+        email=os.environ["GARMIN_EMAIL"],
+        password=os.environ["GARMIN_PASSWORD"],
+    )
+
+    # トークンでログイン → 失敗時はクレデンシャルでフォールバック
+    try:
+        client.login(tokenstore=TOKENSTORE)
+    except (FileNotFoundError, GarminConnectAuthenticationError):
+        print("トークンが無効または未保存のため、クレデンシャルでログインします")
+        client.login()
+    print("ログイン成功")
+
+    # リフレッシュ済みトークンを保存
+    client.garth.dump(TOKENSTORE)
+    print(f"トークン保存完了: {TOKENSTORE}")
+
+    # GCSにアップロード
+    gcs_client = storage.Client()
+    gcs_bucket = gcs_client.bucket(bucket)
+    for path in Path(TOKENSTORE).rglob("*"):
+        if path.is_dir():
+            continue
+        gcs_path = f"{GCS_TOKEN_PREFIX}/{path.relative_to(TOKENSTORE)}"
+        gcs_bucket.blob(gcs_path).upload_from_filename(str(path))
+        print(f"  アップロード: gs://{bucket}/{gcs_path}")
+    print("GCSアップロード完了")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_upload_garmin_tokens.py
+++ b/tests/test_upload_garmin_tokens.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from garminconnect import GarminConnectAuthenticationError  # type: ignore[import-untyped]
+
+from scripts.upload_garmin_tokens import main
+
+
+def test_missing_env_vars_exits(monkeypatch):
+    """必須環境変数が未設定の場合、エラー終了する。"""
+    monkeypatch.delenv("GARMIN_EMAIL", raising=False)
+    monkeypatch.delenv("GARMIN_PASSWORD", raising=False)
+    monkeypatch.delenv("RUN_COACH_GCS_BUCKET", raising=False)
+
+    with pytest.raises(SystemExit, match="1"):
+        main()
+
+
+def test_partial_env_vars_exits(monkeypatch):
+    """一部の環境変数のみ設定されている場合もエラー終了する。"""
+    monkeypatch.setenv("GARMIN_EMAIL", "test@example.com")
+    monkeypatch.delenv("GARMIN_PASSWORD", raising=False)
+    monkeypatch.delenv("RUN_COACH_GCS_BUCKET", raising=False)
+
+    with pytest.raises(SystemExit, match="1"):
+        main()
+
+
+@patch("scripts.upload_garmin_tokens.storage")
+@patch("scripts.upload_garmin_tokens.Garmin")
+def test_token_login_success(mock_garmin_cls, mock_storage, monkeypatch, tmp_path):
+    """正常系: トークンログインが成功し、GCSにアップロードされる。"""
+    monkeypatch.setenv("GARMIN_EMAIL", "test@example.com")
+    monkeypatch.setenv("GARMIN_PASSWORD", "secret")
+    monkeypatch.setenv("RUN_COACH_GCS_BUCKET", "my-bucket")
+
+    mock_client = MagicMock()
+    mock_garmin_cls.return_value = mock_client
+
+    # garth.dump がトークンファイルを作成するのをシミュレート
+    token_dir = tmp_path / ".garminconnect"
+    token_dir.mkdir()
+    (token_dir / "oauth1_token.json").write_text("{}")
+    (token_dir / "oauth2_token.json").write_text("{}")
+    monkeypatch.setattr("scripts.upload_garmin_tokens.TOKENSTORE", str(token_dir))
+
+    main()
+
+    mock_client.login.assert_called_once_with(tokenstore=str(token_dir))
+    mock_client.garth.dump.assert_called_once_with(str(token_dir))
+    mock_storage.Client.assert_called_once()
+    mock_bucket = mock_storage.Client().bucket("my-bucket")
+    assert mock_bucket.blob.call_count >= 1
+
+
+@patch("scripts.upload_garmin_tokens.storage")
+@patch("scripts.upload_garmin_tokens.Garmin")
+def test_fallback_to_credential_login(
+    mock_garmin_cls, mock_storage, monkeypatch, tmp_path
+):
+    """トークンログイン失敗時にクレデンシャルログインへフォールバックする。"""
+    monkeypatch.setenv("GARMIN_EMAIL", "test@example.com")
+    monkeypatch.setenv("GARMIN_PASSWORD", "secret")
+    monkeypatch.setenv("RUN_COACH_GCS_BUCKET", "my-bucket")
+
+    mock_client = MagicMock()
+    mock_garmin_cls.return_value = mock_client
+    mock_client.login.side_effect = [
+        GarminConnectAuthenticationError("token expired"),
+        None,
+    ]
+
+    token_dir = tmp_path / ".garminconnect"
+    token_dir.mkdir()
+    (token_dir / "oauth1_token.json").write_text("{}")
+    monkeypatch.setattr("scripts.upload_garmin_tokens.TOKENSTORE", str(token_dir))
+
+    main()
+
+    assert mock_client.login.call_count == 2
+    mock_client.login.assert_has_calls([call(tokenstore=str(token_dir)), call()])
+    mock_client.garth.dump.assert_called_once_with(str(token_dir))
+
+
+@patch("scripts.upload_garmin_tokens.storage")
+@patch("scripts.upload_garmin_tokens.Garmin")
+def test_fallback_on_missing_tokenstore(
+    mock_garmin_cls, mock_storage, monkeypatch, tmp_path
+):
+    """トークンファイルが存在しない場合もクレデンシャルでログインする。"""
+    monkeypatch.setenv("GARMIN_EMAIL", "test@example.com")
+    monkeypatch.setenv("GARMIN_PASSWORD", "secret")
+    monkeypatch.setenv("RUN_COACH_GCS_BUCKET", "my-bucket")
+
+    mock_client = MagicMock()
+    mock_garmin_cls.return_value = mock_client
+    mock_client.login.side_effect = [FileNotFoundError("no tokens"), None]
+
+    token_dir = tmp_path / ".garminconnect"
+    token_dir.mkdir()
+    (token_dir / "oauth1_token.json").write_text("{}")
+    monkeypatch.setattr("scripts.upload_garmin_tokens.TOKENSTORE", str(token_dir))
+
+    main()
+
+    assert mock_client.login.call_count == 2
+    mock_client.login.assert_has_calls([call(tokenstore=str(token_dir)), call()])


### PR DESCRIPTION
## Summary

- GarminがクラウドIPからのOAuthトークン交換を429で拒否する問題の暫定対策
- ローカルPC（住宅IP）でトークンをリフレッシュしGCSにアップロードするスクリプトを追加
- `make upload-garmin-tokens` で実行可能

## 変更内容

- `scripts/upload_garmin_tokens.py`: トークンリフレッシュ＋GCSアップロード（初回・トークン破損時のクレデンシャルフォールバック付き）
- `Makefile`: `upload-garmin-tokens` ターゲット追加
- `tests/test_upload_garmin_tokens.py`: 環境変数チェック・正常系・フォールバック系のテスト（5件）

## Test plan

- [x] `uv run pytest tests/test_upload_garmin_tokens.py` — 5件パス
- [x] `uv run ruff check scripts/ tests/` — lint クリア
- [x] ローカルでトークンリフレッシュ＋GCSアップロード動作確認済み

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)