### PR TITLE
feat: Garminトークンの定期自動リフレッシュ (launchd)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
        db-up db-down db-logs db-psql \
        migrate migrate-history migrate-new migrate-down \
        local-coach cloud-coach upload-profile upload-garmin-tokens \
+       garmin-cron-install garmin-cron-uninstall \
        gcp-set-project \
        scheduler-create scheduler-delete scheduler-run scheduler-describe \
        check-activity-run \
@@ -83,6 +84,17 @@ gcp-set-project: ## GCPプロジェクトを切り替え（要: RUN_COACH_GCP_PR
 
 upload-garmin-tokens: ## Garminトークンをリフレッシュし GCS にアップロード（要: GARMIN_EMAIL, GARMIN_PASSWORD, RUN_COACH_GCS_BUCKET）
 	uv run python -m scripts.upload_garmin_tokens
+
+GARMIN_CRON_PLIST := $(HOME)/Library/LaunchAgents/com.run-coach.upload-garmin-tokens.plist
+
+garmin-cron-install: ## Garminトークン定期リフレッシュを登録（毎日10:00）
+	launchctl bootout gui/$$(id -u) $(GARMIN_CRON_PLIST) 2>/dev/null || true
+	launchctl bootstrap gui/$$(id -u) $(GARMIN_CRON_PLIST)
+	@echo "登録完了: 毎日 10:00 に Garmin トークンをリフレッシュします"
+
+garmin-cron-uninstall: ## Garminトークン定期リフレッシュを解除
+	launchctl bootout gui/$$(id -u) $(GARMIN_CRON_PLIST)
+	@echo "解除完了"
 
 upload-profile: ## profile.yaml を GCS にアップロード（要: RUN_COACH_GCS_BUCKET 環境変数）
 	@test -n "$(RUN_COACH_GCS_BUCKET)" || (echo "Error: RUN_COACH_GCS_BUCKET 環境変数が未設定です" && exit 1)

--- a/scripts/launchd_upload_garmin_tokens.sh
+++ b/scripts/launchd_upload_garmin_tokens.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# launchd から呼ばれるラッパースクリプト
+# .zprofile から export 行を抽出して環境変数をロードする
+
+set -euo pipefail
+
+LOG_FILE="/tmp/upload-garmin-tokens.log"
+PROJECT_DIR="$HOME/Personal_Projects/run-coach"
+
+{
+    echo "=== $(date '+%Y-%m-%d %H:%M:%S') ==="
+
+    # .zprofile から export 文のみ抽出してロード（zsh固有コマンドを回避）
+    eval "$(grep '^export ' "$HOME/.zprofile")"
+
+    # homebrew の PATH を設定
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+
+    cd "$PROJECT_DIR"
+    /opt/homebrew/bin/uv run python -m scripts.upload_garmin_tokens
+
+    echo "完了"
+    echo ""
+} >> "$LOG_FILE" 2>&1


### PR DESCRIPTION
## Summary
- macOS launchd で毎朝10:00に `upload_garmin_tokens` を自動実行するよう設定
- `StartCalendarInterval` を使用し、スリープ復帰時にも未実行分を補完実行
- `make garmin-cron-install` / `make garmin-cron-uninstall` でセットアップ・解除

## Test plan
- [x] `make garmin-cron-install` で登録確認
- [x] `launchctl kickstart` で手動トリガーし、トークンリフレッシュ＆GCSアップロード成功を確認
- [x] ログ出力確認 (`/tmp/upload-garmin-tokens.log`)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)